### PR TITLE
BitStory interactive consensus activity

### DIFF
--- a/syllabus/2-Blockchain/2.2-Consensus_Systems/2.2-Consensus_Systems_Activities.md
+++ b/syllabus/2-Blockchain/2.2-Consensus_Systems/2.2-Consensus_Systems_Activities.md
@@ -1,0 +1,56 @@
+# BitStory: Hands-on Consensus games
+
+In this activity students will encounter and explore blockchain consensus mechanisms (especially PoW) by acting them out manually.
+
+Students will collaborate in telling a shared story. The shared story is represented by a blockchain with one word in each block. To add a word to the story, a student must create a valid block, and draw that block on the community whiteboard*
+
+![Photo of bitstory content on whiteboard](https://joshorndorff.github.io/BitStory/bitStoryLive.jpg)
+
+* If no whiteboard is available, you may be able to substitute, a paper, online drawing tool, or even a chalkboard if you are desparate.
+
+## Proof of Work
+
+The PoW phase is the original, and a working hasher tool is available here: https://joshorndorff.github.io/BitStory/bitStoryLive.html
+
+To begin we'll explore the Nakamoto style Proof of Work. To add a block a student must:
+* Choose a parent block hash to build on
+* Choose a word to add to the story
+* Find a nonce so that the block's hash meets the required difficulty
+
+The process of finding a nonce is accomplished by entering the parent hash and word into [the hasher](https://joshorndorff.github.io/BitStory/bitStoryLive.html) and repeatedly mashing the `increment nonce` button until you find a valid one. In this way students are manually performing the preimage search.
+
+You may choose that the game ends at a certain time. You may choose a winner by who created the most blocks. Or who made the story unfold most to their liking
+
+### Additions
+
+The instructor can encourage student groups to perform various attacks on the PoW network.
+
+* Censor specific words or plot points by forking around them
+* Perform a hard fork where your block start to have two words each. Some students will like the two-words-per-block rule and keep building on them. Other students (ideally ones who don't know the instructor is in on the shenanigans) may think the two-word blocks are not following the rules, and choose to ignore them. Welcome to bitstory cash.
+
+
+## Proof of Authority (Aura)
+In this phase, students will choose some authorities to act as block authors and a slot duration and they will take turns authoring in order. They should observe that this method is much simpler and less chaotic. It does indeed take less work.
+
+Again, the instructor introduces some chaos
+
+* Encourage some authorities to skip their slots
+* Encourage authorities to censor words.
+* Polarize the authorites to work on two different forks
+
+## Discussion
+What attacks worked best in PoW vs PoA. What strengths and eweaknesses does each have.
+
+## Rotating Authorities
+Challenge the students to consider whays in which the authority set might change. What if the story itself is about who is elected as authorities.
+
+Notice that this is the foundation of proof of stake. The on-chain story is about people bonding and unbonding their security deposits.
+
+## Grandpa
+
+This one is a little different. Here we assume an external block production method. At first this can just be one student who is not playing grandpa, but instead being the sole block producer.
+
+The other students use a shared whiteboard to post their pre-votes and pre-commits and personal paper to track which blocks they have finalized.
+
+## Hybrid Consensus
+If their is time in the activity slot, we can cobine any of the block production methods with grandpa. My personal favorite is PoW + Grandpa.


### PR DESCRIPTION
This PR adds a hands-on activity called BitStory to section 2.2 - Consensus Systems.

In the activity, students will manually act out the roles of authoring nodes (and finality voters in the later stages) to reach consensus over a shared story that they are telling on a hand-drawn blockchain.

@AlistairStewart I see you are listed as the instructor for this section. There were not may activities included yet, so I took the liberty of drafting this one. Please feel free to review it, improve it, offer feedback, nix it, etc. 