### PR TITLE
Add activity idea to 4.3 Censor transactions

### DIFF
--- a/syllabus/4-Substrate/4.3-Transaction_Queue_and_Block_Builder/4.3-Workshops_and_Activities/4.3-Transaction_Queue_and_Block_Builder_Workshop.md
+++ b/syllabus/4-Substrate/4.3-Transaction_Queue_and_Block_Builder/4.3-Workshops_and_Activities/4.3-Transaction_Queue_and_Block_Builder_Workshop.md
@@ -6,3 +6,10 @@ Spam a transaction pool, taking into account:
 - Transaction pool size and weird behavior
 - Modify mortality and tips
 - Incrementing the nonce
+
+# Make your node censor transactions
+
+Modify the code of the substrate node template so that the node will not include transactions of a certain kind. For example maybe censor:
+* token transfers to (or from) a specific address
+* All transactions from a specific account
+* Sudo calls


### PR DESCRIPTION
The idea behind this activity is to show that the transaction pool operates off chain and there is no consensus over it. That means that an individual node can run alternate code in the transaction pool while still producing valid blocks and verifying others' blocks correctly.

As a bonus, the code that needs to be changed is in the runtime (block builder api) which foreshadows the runtime apis discussed in section 4.4.

cc @shawntabrizi because I see you are the instructor for this unit.