### PR TITLE
Scaffold 6.5 Smart Contracts skeleton

### DIFF
--- a/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-1-Smart_Contracts_Slides.md
+++ b/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-1-Smart_Contracts_Slides.md
@@ -16,7 +16,7 @@ teaching-assistants: ["some one", "another gal"]
 <div class="left text-right"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->
 
 <!-- TODO: add a good circularly cropped headshot of ou to the `assets/profile` folder  -->
-<img style="width: 550px; float:right; margin-right:30px" src="../../assets/img/0-Shared/profile.png"/>
+<img style="width: 550px; float:right; margin-right:30px" src="../../../assets/img/0-Shared/profile.png"/>
 
 </div>
 <div style="margin-top:130px" class="right text-left"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->

--- a/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-2-Pallet_Contracts_Slides.md
+++ b/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-2-Pallet_Contracts_Slides.md
@@ -16,7 +16,7 @@ teaching-assistants: ["some one", "another gal"]
 <div class="left text-right"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->
 
 <!-- TODO: add a good circularly cropped headshot of ou to the `assets/profile` folder  -->
-<img style="width: 550px; float:right; margin-right:30px" src="../../assets/img/0-Shared/profile.png"/>
+<img style="width: 550px; float:right; margin-right:30px" src="../../../assets/img/0-Shared/profile.png"/>
 
 </div>
 <div style="margin-top:130px" class="right text-left"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->

--- a/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-3-Ink_Slides.md
+++ b/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-3-Ink_Slides.md
@@ -16,7 +16,7 @@ teaching-assistants: ["some one", "another gal"]
 <div class="left text-right"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->
 
 <!-- TODO: add a good circularly cropped headshot of ou to the `assets/profile` folder  -->
-<img style="width: 550px; float:right; margin-right:30px" src="../../assets/img/0-Shared/profile.png"/>
+<img style="width: 550px; float:right; margin-right:30px" src="../../../assets/img/0-Shared/profile.png"/>
 
 </div>
 <div style="margin-top:130px" class="right text-left"> <!-- Gotcha: You Need an empty line to render MD inside <div> -->


### PR DESCRIPTION
I'm simply adding a basic skeleton.

The generated index HTML looks strange:

![0](https://user-images.githubusercontent.com/241530/173597478-fd01b5c9-ad18-4fe3-83c5-a9f693d0caeb.png)

@sacha-l I suspect because of the sub-chapter numbering 6.5.1, 6.5.2, etc.. Doesn't seem to affect anything else.