### PR TITLE
reveal-md / fix build issues

### DIFF
--- a/reveal-md.json
+++ b/reveal-md.json
@@ -21,7 +21,7 @@
   "listingTemplate": "./reveal-md/listing-template.html",
   "host": "localhost",
   "staticDir": "build",
-  "staticDirs": ["assets", "plugin"],
+  "staticDirs": ["assets"],
   "preprocessor": null,
   "glob": "**/*[Ss]lides.md"
 }

--- a/reveal-md/slide-template.html
+++ b/reveal-md/slide-template.html
@@ -52,7 +52,6 @@
     <script src="{{{base}}}/plugin/zoom/zoom.js"></script>
     <script src="{{{base}}}/plugin/notes/notes.js"></script>
     <script src="{{{base}}}/plugin/math/math.js"></script>
-    <script type="module" src="{{{base}}}/plugin/design-system/design-system.js"></script>
     <script>
       function extend() {
         var target = {};


### PR DESCRIPTION
this PR addresses build issues (`yarn build`):

- [x] custom web-components are not rendered
- [x] some css missing in the build assets, fixed by adding to reveal-md.json
- [ ] slide html files request `<link rel="stylesheet" href="./../../.././reveal-md/fonts/" />`, which throws MIME error (the fix could be to add the fonts specifically in reveal-md.json)
