### PR TITLE
fix: import design system plugin

### DIFF
--- a/reveal-md/slide-template.html
+++ b/reveal-md/slide-template.html
@@ -52,6 +52,7 @@
     <script src="{{{base}}}/plugin/zoom/zoom.js"></script>
     <script src="{{{base}}}/plugin/notes/notes.js"></script>
     <script src="{{{base}}}/plugin/math/math.js"></script>
+    <script type="module" src="{{{base}}}/plugin/design-system/design-system.js"></script>
     <script>
       function extend() {
         var target = {};


### PR DESCRIPTION
Fixing a bug preventing the design system to be imported.

Introduced in a squashed commit in last PRs.