### PR TITLE
Feat/img is loaded

### DIFF
--- a/assets/styles/polkadot-theme-base.css
+++ b/assets/styles/polkadot-theme-base.css
@@ -244,12 +244,14 @@ a:visited {
 
 widget-image {
   transition: opacity 666ms ease-in-out;
+  transition-delay: 222ms;
   transform: scale(1);
+  opacity: 0;
 }
-.present widget-image {
+.present widget-image[is-loaded] {
   opacity: 1;
 }
-.future widget-image,
-.past widget-image {
+.future widget-image[is-loaded],
+.past widget-image[is-loaded] {
   opacity: 0;
 }

--- a/plugin/design-system/index.css
+++ b/plugin/design-system/index.css
@@ -138,7 +138,7 @@ widget-speaker-social-link-title {
 }
 
 /* speaker card when within slides */
-.stack.present widget-speaker-image {
+.stack.present widget-speaker-image[is-loaded] {
   transform: scale(1);
   opacity: 1;
 }

--- a/plugin/design-system/widget-image.js
+++ b/plugin/design-system/widget-image.js
@@ -22,6 +22,9 @@ export default class WidgetImage extends HTMLElement {
   render() {
     if (this.src) {
       const $img = document.createElement('img');
+      $img.addEventListener('load', () => {
+        this.setAttribute('is-loaded', true)
+      })
       if (this.baseUrl) {
         $img.src = `${this.baseUrl}/${this.src}`;
       } else {

--- a/plugin/design-system/widget-speaker.js
+++ b/plugin/design-system/widget-speaker.js
@@ -62,6 +62,9 @@ export default class WidgetSpeaker extends HTMLElement {
 
     const $speakerImage = document.createElement('widget-speaker-image');
     const $img = document.createElement('img');
+    $img.addEventListener('load', () => {
+      $speakerImage.setAttribute('is-loaded', true)
+    })
     if (this.baseUrl) {
       $img.src = `${this.baseUrl}/${this.image}`;
     } else {


### PR DESCRIPTION
- add `is-loaded` on widget with images when they are loaded, to transition display of images smoothly when online (and img request might be long[er])