### PR TITLE
Remove ink! illustrator todo notes

### DIFF
--- a/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-3-Ink_Slides.md
+++ b/syllabus/6-FRAME/6.5-Smart_Contracts/6.5-3-Ink_Slides.md
@@ -308,15 +308,11 @@ mod tests {
 
 <img style="width: 60%;  margin-right:30px" src="../../../assets/img/6-FRAME/6.5-Smart_Contracts/ink/rpc.svg" />
 
-<!-- TODO: An illustrator should prettify this  -->
-
 ---
 
 ## Reading Contract Values: Events
 
 <img style="width: 65%;  margin-right:30px" src="../../../assets/img/6-FRAME/6.5-Smart_Contracts/ink/events.svg" />
-
-<!-- TODO: An illustrator should prettify this  -->
 
 ---
 


### PR DESCRIPTION
We have an illustrator currently doing a number of graphics for ink!, he'll also do those two anyway for our documentation. So we can remove the todo comments here.