### PR TITLE
Restore proper content for 4.6

### DIFF
--- a/syllabus/4-Substrate/4.6-Consensus_Block_Authoring_and_Finality/4.6-Consensus_Block_Authoring_and_Finality_Slides.md
+++ b/syllabus/4-Substrate/4.6-Consensus_Block_Authoring_and_Finality/4.6-Consensus_Block_Authoring_and_Finality_Slides.md
@@ -40,9 +40,9 @@ In this lecture, we will learn about the consensus protocols implemented in Subs
 - Consensus is a method for coming to agreement over a shared state
 - We want to come to agreement on what is the current canonical block
 
-![Forks](/assets/img/4-Substrate/4.6-forks.png)  <!-- .element height="50%" width="50%" -->
+<img style="width: 500px" src="../../../assets/img/4-Substrate/4.6-forks.png"/>
 
-<!-- TODO: this image is a draft -->
+<!-- TODO DESIGN: this image is a draft -->
 
 Note: the consensus protocols don't care about what the blocks are actually doing, it doesn't care about the STF other than knowing whether it succeeded or not.
 The protocol is just "blindly" coming to consensus on what block hashes are canonical.
@@ -69,11 +69,11 @@ Note: we might need to follow multiple forks temporarily, but the fork choice ru
 ## Finality
 
 - Given a certain state / block how certain can we be that it is canonical
-    - ... and that it will stay canonical
+  - ... and that it will stay canonical
 - If we're certain that a block is canonical we consider it to be **finalized**
 - This property can be either:
-    - Probabilistic
-    - Definite / Provable
+  - Probabilistic
+  - Definite / Provable
 
 Note: the practical notion we're trying to solve here is whether a given block is canonical or not, if it's not canonical it is possible that it might be reverted in the future. Probabilistic finality is akin to eventual consistency, different nodes in the network might have different views of the canonical state at different times, but given enough time (unbound) they should all come to the same conclusion.
 
@@ -245,7 +245,7 @@ Note: Read the original Ouroboros Praos paper [here](https://eprint.iacr.org/201
 
 <div class="right">
 
-![Round Robin Diagram](/assets/img/4-Substrate/4.6-slot-assignment.png) <!-- .element height="40%" width="40%" -->
+<img style="width: 500px" src="../../../assets/img/4-Substrate/4.6-slot-assignment.png"/>
 
 </div>
 
@@ -274,7 +274,7 @@ See: https://research.web3.foundation/en/latest/polkadot/block-production/Babe.h
 
 ### Primary slots
 
-![VRF in BABE](/assets/img/4-Substrate/4.6-vrf-in-babe.png)
+<img style="width: 900px" src="../../../assets/img/4-Substrate/4.6-vrf-in-babe.png"/>
 
 ---
 
@@ -304,7 +304,7 @@ See: https://research.web3.foundation/en/latest/polkadot/block-production/Babe.h
   - is announced at the beginning of epoch N + 1 (along with the authorities)
   - and used on epoch N + 2
 
-![Forks](/assets/img/4-Substrate/4.6-vrf-seeding.png)  <!-- .element height="50%" width="50%" -->
+<img style="width: 500px" src="../../../assets/img/4-Substrate/4.6-vrf-seeding.png"/>
 
 <!-- TODO: this image is a draft -->
 
@@ -518,7 +518,7 @@ pub struct Precommit<Hash, Number> {
 
 ## Extending BABE's fork choice rule
 
-![GRANDPA](/assets/img/4-Substrate/4.6-fork-choice.png)
+<img style="width: 500px" src="../../../assets/img/4-Substrate/4.6-fork-choice.png"/>
 
 Note: The black blocks are finalized, and the yellow blocks are not.
 Blocks marked with a "1" are primary blocks; those marked with a "2" are secondary blocks.


### PR DESCRIPTION
The merge in https://github.com/paritytech/polkadot-blockchain-academy/pull/221 was incorrect and slides got mangled. This PR restores the content to the previously known good commit from that PR.