### PR TITLE
Notebooks for cryptography lectures

### DIFF
--- a/syllabus/1-Cryptography/1.1-Crypto_Introduction/Hashing.ipynb
+++ b/syllabus/1-Cryptography/1.1-Crypto_Introduction/Hashing.ipynb
@@ -13,7 +13,10 @@
    "execution_count": 2,
    "id": "0e93c254",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "vscode": {
+     "languageId": "rust"
+    }
    },
    "outputs": [
     {
@@ -43,7 +46,11 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "2fb4a413",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [],
    "source": [
     ":dep sp-core = \"3.0\""
@@ -53,7 +60,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "967a9ebc",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [],
    "source": [
     "use sp_core::*;\n",
@@ -64,7 +75,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "be2425e9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -85,7 +100,11 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "594f2834",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -114,7 +133,11 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "71b5c43d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -135,7 +158,11 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "1c5ad26b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -172,7 +199,11 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "3e5f2e31",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -201,7 +232,11 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "ecab16b2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -230,9 +265,29 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e8c231ac",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "rust"
+    }
+   },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ac72150",
+   "metadata": {},
+   "source": [
+    "## Symmetric Encryption"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51a61c3b",
+   "metadata": {},
+   "source": [
+    "No symemtric encryption is included in sp-core. Could use this crate https://docs.rs/aes-gcm-siv/latest/aes_gcm_siv/"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
During the first iteration of the Academy, Gav did some live Rust coding in the EvCxR REPL to demonstrate some cryptographic concepts and how to use the corresponding Rust crates. Because it was live, this content was never captured in the version control system.

This PR adds that content in the form of Jupyer notebooks that also use the EvCxR backend.