### PR TITLE
Publish mods 1 and 2 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Selected through an admission process, candidates will receive an intensive educ
 
 ## Curriculum Versions
 
-The curriculum is expected to change per cohort in the first run. You can find the snapshot of the slides at the end of each cohort here: 
+The curriculum is expected to change per cohort in the first run. You can find the snapshot of the slides at the end of each cohort here:
 
 - [Cambridge 2022](https://github.com/Polkadot-Blockchain-Academy/pba-content/tree/cambridge-2022)
 

--- a/reveal-md.json
+++ b/reveal-md.json
@@ -11,5 +11,5 @@
   "staticDir": "build",
   "staticDirs": ["assets"],
   "preprocessor": null,
-  "glob": "**/*[Ss]lides.md"
+  "glob": "syllabus/[1,2]*/**/*[Ss]lides.md"
 }


### PR DESCRIPTION
As a partial fix for #449 we can simply not build & publish all slides.

This PR only publishes mod 1 and 2 