### PR TITLE
Fix build & publish

### DIFF
--- a/syllabus/4-Substrate/4.1-Intro-to-Substrate_Slides.md
+++ b/syllabus/4-Substrate/4.1-Intro-to-Substrate_Slides.md
@@ -8,7 +8,7 @@ teaching-assistants: ["..."]
 
 # Introduction to Substrate
 
-<widget-speaker name="Kian Paimani" position="Core Dev" image="../../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
+<widget-speaker name="Kian Paimani" position="Core Dev" image="../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
 
 ---
 
@@ -22,8 +22,7 @@ Substrate is a **Rust framework** for **building blockchains** in a modular and 
 
 * ⛓️ Future is multi-chain.
 
-<img width="800px" src="../../../assets/img/4-Substrate/dev-4.1-maximalism.png"></img>
-
+<img width="800px" src="../../assets/img/4-Substrate/dev-4.1-maximalism.png"></img>
 
 ---v
 
@@ -88,7 +87,7 @@ Outcomes of this:
 ### Core Philosophies of Substrate: Rust as a language
 
 
-<img width="1400px" src="../../../assets/img/4-Substrate/dev-4-1-speed.png"></img>
+<img width="1400px" src="../../assets/img/4-Substrate/dev-4-1-speed.png"></img>
 
 
 
@@ -121,7 +120,7 @@ Outcomes of this:
 
 ### Substrate Architecture
 
-<img src="../../../assets/img/4-Substrate/dev-4-1-substrate.svg"></img>
+<img src="../../assets/img/4-Substrate/dev-4-1-substrate.svg"></img>
 
 ---
 
@@ -154,7 +153,7 @@ Outcomes of this:
 ### State Transition
 
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-1-state.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-1-state.svg"></img>
 
 ---v
 
@@ -202,19 +201,19 @@ Outcomes of this:
 ### 😎 Forkless Upgrade:
 
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-1-forkless-1.svg" />
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-1-forkless-1.svg" />
 
 ---v
 
 ### 😎 Forkless Upgrade:
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-1-forkless-2.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-1-forkless-2.svg" />
 
 ---v
 
 ### What is WASM Anyways?
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-1-wasm-langs.svg">
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-1-wasm-langs.svg">
 
 ---v
 
@@ -234,7 +233,7 @@ Outcomes of this:
 
 <pba-col center>
 
-<img style="height: 700px;" src="../../../assets/img/4-Substrate/dev-4-1-wasm.svg">
+<img style="height: 700px;" src="../../assets/img/4-Substrate/dev-4-1-wasm.svg">
 
 </pba-col>
 
@@ -257,7 +256,7 @@ A marvel of universe 🤯.
 
 <pba-col center>
 
-<img style="width: 800px;" src="../../../assets/img/4-Substrate/dev-4-1-smoldot.svg">
+<img style="width: 800px;" src="../../assets/img/4-Substrate/dev-4-1-smoldot.svg">
 
 </pba-col>
 
@@ -291,7 +290,7 @@ just spoke of.
 
 ### The Client
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-full.svg">
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-full.svg">
 
 ---v
 
@@ -342,7 +341,7 @@ Because the runtime can change independently!
 
 <pba-col center>
 
-<img style="width: 1000px" src="../../../assets/img/4-Substrate/dev-4-1-state-opaqueu.svg">
+<img style="width: 1000px" src="../../assets/img/4-Substrate/dev-4-1-state-opaqueu.svg">
 
 </pba-col>
 
@@ -352,13 +351,13 @@ Because the runtime can change independently!
 
 ## Communication Paths
 
-<img style="width: 1400px" src="../../../assets/img/4-Substrate/dev-4-1-comms.svg">
+<img style="width: 1400px" src="../../assets/img/4-Substrate/dev-4-1-comms.svg">
 
 ---v
 
 ### Communication Paths
 
-<img style="width: 1400px" src="../../../assets/img/4-Substrate/dev-4-1-comms-format.svg">
+<img style="width: 1400px" src="../../assets/img/4-Substrate/dev-4-1-comms-format.svg">
 
 ---v
 
@@ -428,14 +427,14 @@ fn main() {
 <pba-cols>
 <pba-col center>
 
-<img src="../../../assets/img/4-Substrate/nintendo-console-2.png" style="width:400px;"/>
+<img src="../../assets/img/4-Substrate/nintendo-console-2.png" style="width:400px;"/>
 
 Substrate Client
 
 </pba-col>
 <pba-col center>
 
-<img src="../../../assets/img/4-Substrate/nintendo-game.png" style="width:400px;"/>
+<img src="../../assets/img/4-Substrate/nintendo-game.png" style="width:400px;"/>
 
 Substrate Runtime
 
@@ -455,13 +454,13 @@ https://www.cleanpng.com/png-game-boy-advance-deviantart-video-game-consoles-218
 
 ## Substrate and Polkadot
 
-<img style="width: 1300px;" src="../../../assets/img/4-Substrate/dev-4-1-polkadot.svg">
+<img style="width: 1300px;" src="../../assets/img/4-Substrate/dev-4-1-polkadot.svg">
 
 ---
 
 ## Technical Freedom vs Ease
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-1-freedom.svg"/>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-1-freedom.svg"/>
 
 
 ---

--- a/syllabus/4-Substrate/4.2-Substrate-Folder-Structure_Slides.md
+++ b/syllabus/4-Substrate/4.2-Substrate-Folder-Structure_Slides.md
@@ -8,7 +8,7 @@ teaching-assistants: ["..."]
 
 # Substrate Folder Structure
 
-<widget-speaker name="Kian Paimani" position="Core Dev" image="../../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
+<widget-speaker name="Kian Paimani" position="Core Dev" image="../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
 
 ---
 
@@ -88,7 +88,7 @@ Primitives is the glue between the other two.
 
 ### Substrate Externally
 
-<img style="width: 1200px" src="../../../assets/img/4-Substrate/dev-4-2-external.svg">
+<img style="width: 1200px" src="../../assets/img/4-Substrate/dev-4-2-external.svg">
 
 ---v
 
@@ -96,7 +96,7 @@ Primitives is the glue between the other two.
 
 * Remember this? this is the node-template layer
 
-<img style="width: 800px;" src="../../../assets/img/4-Substrate/dev-4-1-freedom.svg"/>
+<img style="width: 800px;" src="../../assets/img/4-Substrate/dev-4-1-freedom.svg"/>
 
 
 NOTE:

--- a/syllabus/4-Substrate/4.3-WASM-Meta-Protocol-Slides.md
+++ b/syllabus/4-Substrate/4.3-WASM-Meta-Protocol-Slides.md
@@ -8,7 +8,7 @@ teaching-assistants: [""]
 
 # Substrate WASM Meta Protocol
 
-<widget-speaker name="Kian Paimani" position="Core Dev" image="../../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
+<widget-speaker name="Kian Paimani" position="Core Dev" image="../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
 
 ---
 
@@ -51,14 +51,13 @@ Bold claim:
 
 <br>
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-substrate-wasm.png" />
-
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-substrate-wasm.png" />
 
 ---
 
 ## Substrate: a short recap
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-full-comm.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-full-comm.svg" />
 
 ---v
 
@@ -154,7 +153,7 @@ mod well_known_keys {
 
 ### Example #1: State
 
-<img style="width: 1000px;" src="../../../assets/img/4-Substrate/dev-4-1-state-opaqueu.svg" />
+<img style="width: 1000px;" src="../../assets/img/4-Substrate/dev-4-1-state-opaqueu.svg" />
 
 ---
 
@@ -408,7 +407,7 @@ What happens within the runtime defined what is a valid block. The state root ch
 
 ### Example #2: Block Import: Recap
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-import.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-import.svg" />
 
 ---
 
@@ -420,7 +419,7 @@ What happens within the runtime defined what is a valid block. The state root ch
 
 * Let's first talk about this over the figure!
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-full.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-full.svg" />
 
 ---v
 
@@ -525,7 +524,7 @@ hardcoded key where the code is supposed to be stored.
 
 ### Example #4: Runtime Upgrade
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-upgrade.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-upgrade.svg" />
 
 ---v
 
@@ -615,7 +614,7 @@ This is why forkless upgrades are possible in substrate.
 
 ## Substrate: The Full Picture
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-full.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-full.svg" />
 
 ---
 
@@ -748,7 +747,7 @@ let hashed_value = sp_io::storage::get(b"key")
 </pba-col>
 <pba-col center>
 
-<img style="width: 700px;" src="../../../assets/img/4-Substrate/dev-4-3-io.svg" />
+<img style="width: 700px;" src="../../assets/img/4-Substrate/dev-4-3-io.svg" />
 
 </pba-col>
 </pba-cols>
@@ -781,7 +780,7 @@ wasm can be bigger than the actual hashing cost.
 
 ### Consideration: Native Runtime
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-native.svg" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-native.svg" />
 
 ---v
 
@@ -849,13 +848,13 @@ But, if some are executing native, then you will have a consensus error.
 
 ## Speaking of Versions..
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-telemetry.png" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-telemetry.png" />
 
 ---v
 
 ## Speaking of Versions..
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-3-PJS.png" />
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-3-PJS.png" />
 
 ---
 

--- a/syllabus/4-Substrate/4.4-Merkle-db_slides.md
+++ b/syllabus/4-Substrate/4.4-Merkle-db_slides.md
@@ -7,7 +7,7 @@ teaching-assistants: ["..."]
 
 # Substrate Storage
 
-<widget-speaker name="Kian Paimani" position="Core Dev" image="../../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
+<widget-speaker name="Kian Paimani" position="Core Dev" image="../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
 
 ---
 
@@ -15,7 +15,7 @@ teaching-assistants: ["..."]
 
 
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-storage-1.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-storage-1.svg"></img>
 
 ---v
 
@@ -45,7 +45,7 @@ By convention, an externality has a "**backend**" that is in charge of dealing w
 
 ### Substrate Storage: Key Value
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-storage-2.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-storage-2.svg"></img>
 
 ---v
 
@@ -62,7 +62,7 @@ By convention, an externality has a "**backend**" that is in charge of dealing w
 
 ### Substrate Storage: Key Value
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-kv-backend.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-kv-backend.svg"></img>
 
 
 ---v
@@ -96,7 +96,7 @@ THE WHOLE DATABASE 😱.
 
 ### Substrate Storage: Merklized
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-simple.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-simple.svg"></img>
 
 ---v
 
@@ -121,23 +121,23 @@ how many do we mean by "multiple"? depends on how the trie is structured, and th
 ---v
 
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-walk-0.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-walk-0.svg"></img>
 
 ---v
 
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-walk-1.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-walk-1.svg"></img>
 
 ---v
 
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-walk-2.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-walk-2.svg"></img>
 
 ---v
 
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-walk-full.svg"></img>
-
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-walk-full.svg"></img>
+[](../../)
 ---v
 
 ### Substrate Storage: Merklized
@@ -146,7 +146,7 @@ how many do we mean by "multiple"? depends on how the trie is structured, and th
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-proof.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-proof.svg"></img>
 
 NOTE: dark blue are the proof, light blue's hashes are present.
 
@@ -170,7 +170,7 @@ NOTE: dark blue are the proof, light blue's hashes are present.
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-proof-fat.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-proof-fat.svg"></img>
 
 
 ---v
@@ -192,7 +192,7 @@ struct RuntimeVersion {
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-proof-fat-fix.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-proof-fat-fix.svg"></img>
 
 
 ---
@@ -211,7 +211,7 @@ struct RuntimeVersion {
 
 ### Substrate Storage: Base-16 Merklized
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-trie-backend-16.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-trie-backend-16.svg"></img>
 
 ---v
 
@@ -226,7 +226,7 @@ struct RuntimeVersion {
 
 ### Unbalanced Tree
 
-<img style="width: 800px;" src="../../../assets/img/4-Substrate/dev-trie-backend-unbalanced.svg"></img>
+<img style="width: 800px;" src="../../assets/img/4-Substrate/dev-trie-backend-unbalanced.svg"></img>
 
 ---v
 
@@ -248,7 +248,7 @@ The main prevention is using a cryptographically secure hash function on the fra
 
 ## Substrate Storage: The Updated Picture
 
-<img style="width: 1000px;" src="../../../assets/img/4-Substrate/dev-storage-3.svg"></img>
+<img style="width: 1000px;" src="../../assets/img/4-Substrate/dev-storage-3.svg"></img>
 
 ---
 
@@ -291,29 +291,29 @@ one one `Overlay`. When creating a block, I am not sure. Either way, that's not 
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay.svg"></img>
 
 NOTE:
 TODO: boundary of what is client/runtime
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-1.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-1.svg"></img>
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-2.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-2.svg"></img>
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-3.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-3.svg"></img>
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-4.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-4.svg"></img>
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-5.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-5.svg"></img>
 
 ---v
 
@@ -338,7 +338,7 @@ let in_memory = temp;
 </pba-col>
 <pba-col>
 
-<img src="../../../assets/img/4-Substrate/dev-4-3-io.svg"></img>
+<img src="../../assets/img/4-Substrate/dev-4-3-io.svg"></img>
 
 </pba-col>
 
@@ -375,11 +375,11 @@ NOTE:
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-nested.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-nested.svg"></img>
 
 ---v
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-overlay-nested-1.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-overlay-nested-1.svg"></img>
 
 ---v
 
@@ -440,7 +440,7 @@ NO! overlay works on the level on key-values, ot knows nothing of trie nodes, an
 
 ### Substrate Storage: Final Figure
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-storage-full.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-storage-full.svg"></img>
 
 
 ---v
@@ -484,7 +484,7 @@ SomeExternalities.execute_with(|| {
 
 ## Child Trees
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-3-child.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-3-child.svg"></img>
 
 ---v
 
@@ -515,22 +515,22 @@ Surely not.
 
 ### State Pruning
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-3-pruning-1.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-3-pruning-1.svg"></img>
 ---v
 
 ### State Pruning
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-3-pruning-2.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-3-pruning-2.svg"></img>
 ---v
 
 ### State Pruning
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-3-pruning-3.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-3-pruning-3.svg"></img>
 ---v
 
 ### State Pruning
 
-<img style="width: 1400px;" src="../../../assets/img/4-Substrate/dev-4-3-pruning-4.svg"></img>
+<img style="width: 1400px;" src="../../assets/img/4-Substrate/dev-4-3-pruning-4.svg"></img>
 
 
 

--- a/syllabus/4-Substrate/4.x-JSON-RPC_slides.md
+++ b/syllabus/4-Substrate/4.x-JSON-RPC_slides.md
@@ -10,14 +10,14 @@ teaching-assistants: ["..."]
 
 ..and its usage in Substrate.
 
-<widget-speaker name="Kian Paimani" position="Core Dev" image="../../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
+<widget-speaker name="Kian Paimani" position="Core Dev" image="../../assets/img/0-Shared/people/kian.png" github="kianenigma" twitter="kianenigma"></widget-speaker>
 
 
 ---
 
 ### The Need For a Common Language
 
-<img style="width: 1200px;" src="../../../assets/img/4-Substrate/dev-4-json.svg"></img>
+<img style="width: 1200px;" src="../../assets/img/4-Substrate/dev-4-json.svg"></img>
 
 ---
 

--- a/syllabus/4-Substrate/4.x-PJS-api_slides.md
+++ b/syllabus/4-Substrate/4.x-PJS-api_slides.md
@@ -14,7 +14,7 @@ teaching-assistants: ["Sacha Lansky"]
 
 - De facto library to work with all FRAME-based substrate runtimes.
 
-<img src="../../../assets/img/6-FRAME/pjs.png" style="width: 500px"></img>
+<img src="../../assets/img/6-FRAME/pjs.png" style="width: 500px"></img>
 
 ---v
 

--- a/syllabus/4-Substrate/4.x-SCALE_Slides.md
+++ b/syllabus/4-Substrate/4.x-SCALE_Slides.md
@@ -33,13 +33,15 @@ Wasm is a little endian system, which makes SCALE very performant.
 <pba-cols>
 <pba-col center>
 
-<img src="../../../assets/img/4-Substrate/Big-Endian.svg" style="background-color: white; border-radius: 10%; border: 5px solid red;">
+<!-- <img src="../../assets/img/4-Substrate/Big-Endian.svg" style="background-color: white; border-radius: 10%; border: 5px solid red;"> -->
+
+TODO use img that does not break `yarn build`
 
 </pba-col>
 
 <pba-col center>
 
-<img src="../../../assets/img/4-Substrate/Little-Endian.svg" style="background-color: white; border-radius: 10%; border: 5px solid green;">
+<img src="../../assets/img/4-Substrate/Little-Endian.svg" style="background-color: white; border-radius: 10%; border: 5px solid green;">
 
 </pba-col>
 </pba-cols>

--- a/syllabus/5-FRAME/4-Exotic_Stuff/FRAME_Storage_Slides.md
+++ b/syllabus/5-FRAME/4-Exotic_Stuff/FRAME_Storage_Slides.md
@@ -192,13 +192,17 @@ So verify first, write last should not be needed anymore within the FRAME pallet
 
 ## Patricia Trie
 
-<img style="height: 600px;" src="../../../assets/img/4-Substrate/patricia-trie.svg" />
+<!-- <img style="height: 600px;" src="../../../assets/img/4-Substrate/patricia-trie.svg" /> -->
+
+TODO use img that does not break `yarn build`
 
 ---
 
 ## Storage Keys
 
-<img src="../../../assets/img/4-Substrate/navigate-storage-2.svg" />
+<!-- <img src="../../../assets/img/4-Substrate/navigate-storage-2.svg" /> -->
+
+TODO use img that does not break `yarn build`
 
 ---
 


### PR DESCRIPTION
We must not break `yarn build` on `main` , this happens most often when images are not found when moving files in higher/lower directories. If we do, the hosted version doesn't get updated, and students are using these presently.

Note that comments including links to images actually do break the build... don't include them at all :face_exhaling: 

#450 introduced some file issues - please check the build locally before you merge :pray: 