### PR TITLE
Remove unused exercise/activity in XCM lesson 1

### DIFF
--- a/syllabus/7-XCM/1-Core_Concepts_of_XCM/Core_Concepts_of_XCM_slides.md
+++ b/syllabus/7-XCM/1-Core_Concepts_of_XCM/Core_Concepts_of_XCM_slides.md
@@ -260,22 +260,6 @@ This will be very powerful later on (Origins)
 
 ---
 
-## Construct a `MultiLocation`!
-
-<pba-flex center>
-
-1. What is _your_ location?
-1. Where do you _want to send to_?
-1. Write your `MultiLocation`!
-
-Notes:
-
-EXERCISE: Prompt students to decide whe a MultiLocation correctly.
-Encourage non-trivial (but direct!) paths like a specific contract on a parachain from Bitcoin.
-Call on students to state their path and where they want to go.
-
----
-
 ## Cross-Consensus Origins
 
 A `MultiLocation` denoting where an XCM originated from


### PR DESCRIPTION
This was originally an exercise for the students to pretend that each seat they're occupying is a parachain, and where the instructor on the podium acts as the relay chain, and have them try to address another parachain to send messages to.