### PR TITLE
CSS refactor

### DIFF
--- a/assets/styles/PBA-theme.css
+++ b/assets/styles/PBA-theme.css
@@ -290,11 +290,11 @@ pba-flex[right] {
 	padding-left: 2em;
 }
 
-.reveal ol li {
+.reveal ol > li {
   counter-increment: count-ol;
 }
 
-.reveal ol li ol li {
+.reveal * li ol  > li {
   counter-increment: count-ol-ol;
 }
 
@@ -311,7 +311,7 @@ pba-flex[right] {
 	color: var(--r-link-color-hover);
 }
 
-.reveal ol > li::marker {
+.reveal ol > li::before {
 	font-family: "Unbounded";
 	font-size: 0.75em;
 	position: relative;
@@ -323,11 +323,11 @@ pba-flex[right] {
 	font-weight: bold;
 }
 
-.reveal ol > li::marker {
+.reveal ol > li::before {
 	content: counters(count-ol,".") ": ";
 }
 
-.reveal * li ol  > li::marker {
+.reveal * li ol  > li::before {
 	content: counters(count-ol-ol,".") ": ";
 }
 

--- a/syllabus/3-Blockchain/5-Consensus_Finality_slides.md
+++ b/syllabus/3-Blockchain/5-Consensus_Finality_slides.md
@@ -467,14 +467,14 @@ Tendermint is often touted as "instant finality". It is instant in the sense tha
 <li class="fragment">Wait for a block (or author one if it is your turn)</li>
 <li class="fragment">Prevote
   <ul>
-  <li>If the block is valid, Prevote for it.</li>
-  <li>If the block is invalid, Prevote `Nil`</li>
+    <li>If the block is valid, Prevote for it.</li>
+    <li>If the block is invalid, Prevote `Nil`</li>
   </ul>
 </li>
 <li class="fragment">Precommit
   <ul>
-  <li>Wait for 2/3 prevotes then Precommit
-  <li>If you don't get 2/3 prevotes, Precommit `Nil`</div>
+    <li>Wait for 2/3 prevotes then Precommit
+    <li>If you don't get 2/3 prevotes, Precommit `Nil`</div>
   </ul>
 </li>
 <li class="fragment">Complete


### PR DESCRIPTION
Fixes #543 

- [x] Safari doesn't render the same for underline and no `<ol>` numbers show up
 **Solution:** Replace the across-browser unsupported `::marker` with `::before`
- [ ] centered ol and ul on slide (with display: flex perhaps?) without need to wrap in `<pba-flex center>` or any other element by default

> **Note** The solution that you currently have - I think is the best approach so I decided to leave it as is

- [x] default img using md syntax ( `[...](url)` ) mostly works by filling space horizontally as much as reasonable
  - [x] adust md img with no html at all, perhaps a comment below or beside it, just like the `fragment` feature works.

> **This is currently working** the same way as fragment. I already tested it and using this piece of code:
> ```js
> <img rounded style="width: 900px;" src="./img/grandpa-abstract.png" />
> ```
> is the same like using:
> ```js
> ![](./img/grandpa-abstract.png) <!-- .element: style="width: 900px; border-radius: 1.5rem" -->
> ```
> Note: `<!-- .element ...` must be on the same line and pay attention to the `rounded` replaced with actual css code  
> See the outcome below:
![image](https://github.com/Polkadot-Blockchain-Academy/pba-content/assets/5408605/94f5acee-9e01-4829-8a20-0c0c6fc89507)

- [x] correct behavior for numbering of `ol` and `ul` mixed sublists (see comments below);
- [x] Safari doesn't render the same for underline and no `ol` numbers show up';
- [x]  fix bullet padding on next level (cc @BradleyOlson64 )

