### PR TITLE
Substrate @ UCB is 2 full days, then one half day

### DIFF
--- a/syllabus/4-Substrate/README.md
+++ b/syllabus/4-Substrate/README.md
@@ -1,24 +1,24 @@
 ## Day 1
 
-### Morning (~3 hours)
+### Morning (~4 hours max)
 
 1. Lecture: Intro to substrate (60 mins)
 1. Lecture: Wasm-meta protocol Part 1 (45 mins)
 1. Lecture: SCALE (45 mins)
 
-### Afternoon (~3 hours)
+### Afternoon (~4 hours max)
 
 1. Lecture: Wasm-meta protocol Part 2 (60 mins)
 1. Lecture: Transaction Pool (90 mins)
 
 ## Day 2
 
-### Morning (~3 hours)
+### Morning (~4 hours max)
 
 1. Lecture + Activity: JSON-RPC, Interaction with substrate-based chains (60m)
 1. Activity: FRAME-less node-template (rest of the day)
 
-### Afternoon (~3 hours)
+### Afternoon (~4 hours max)
 
 1. Lecture: Substrate Storage (60m)
 1. Workshop: Substrate CLI + Client code Overview
@@ -27,11 +27,11 @@
 
 ## Day 2
 
-### Morning (~3 hours)
+### Morning (~4 hours max)
 
 1. Activity: FRAME-less node-template
 
-### Afternoon (~3 hours)
+### Afternoon (~4 hours max)
 
 > Move to FRAME module
 


### PR DESCRIPTION
Just moved this around to fit the flow now (**internal** calendar here https://www.notion.so/paritytechnologies/cb8e39a25e814f0ea85e7b424da1db91?v=5f1c88d407304f459e421b4ae993d74f )

Please do update, approve and merge as you see fit @kianenigma - the interface / hand-off  with FRAME starting is up to you and @shawntabrizi  to formally decide on, we plan on revealing the schedule for this week sometime the first week of the Academy for the students at UCB inclusive of a bit more granularity on topics covered in the morning and afternoon session.