### PR TITLE
Attempt to fix syntax error in css

### DIFF
--- a/assets/styles/PBA-theme.css
+++ b/assets/styles/PBA-theme.css
@@ -573,6 +573,7 @@ a {
 			 url('./fonts/work-sans/work-sans-v17-latin-italic.woff') format('woff'), /* Modern Browsers */
 			 url('./fonts/work-sans/work-sans-v17-latin-italic.ttf') format('truetype'), /* Safari, Android, iOS */
 			 url('./fonts/work-sans/work-sans-v17-latin-italic.svg#WorkSans') format('svg'); /* Legacy iOS */
+}
 
 /* work-sans-800italic - latin */
 @font-face {


### PR DESCRIPTION
This at least fixes the syntax, but I'm not totally sure it is the right fix. Like maybe this came from a botched merge or something. Should there be two `@font-face` blocks at the bottom? IDK.

Would be nice to have review from a css person. This code blames to #419 but maybe it is older than that?

@wirednkod Do you know if this is a good change?