### PR TITLE
Fix issues with mermaid

### DIFF
--- a/assets/styles/PBA-theme.css
+++ b/assets/styles/PBA-theme.css
@@ -87,7 +87,7 @@ section.has-light-background h6 {
 
 .reveal .slides section,
 .reveal .slides section>section {
-	line-height: 1.3;
+	/* line-height: 1.3; */
 	font-weight: inherit;
 }
 
@@ -229,6 +229,7 @@ pba-flex[right] {
 .mermaid svg{
   margin-left: auto;
   margin-right: auto;
+  max-width: 70% !important;
 }
 
 /* Ensure certain elements are never larger than the slide itself */

--- a/syllabus/6-Polkadot/Light-clients-and-unstoppable-apps/Light-clients-and-unstoppable-apps-slides.md
+++ b/syllabus/6-Polkadot/Light-clients-and-unstoppable-apps/Light-clients-and-unstoppable-apps-slides.md
@@ -4,12 +4,6 @@ description: Light Clients and Unstoppable Apps, for Web3 engineers.
 duration: 45+ mins
 ---
 
-<style type="text/css">
-.lc-mermaid svg {
-  max-width: 70% !important;
-}
-</style>
-
 # Light clients<br/>and<br/>Unstoppable Apps
 
 ---
@@ -426,15 +420,15 @@ Notes:
 
 ---v
 
-<diagram class="mermaid lc-mermaid">
+<diagram class="mermaid">
   stateDiagram-v2
     Smoldot --> Substrate_connect
     Substrate_connect --> PolkadotJS_API
     PolkadotJS_API --> UI_dAPP
 
     Smoldot --> smoldot_libraries(Rust_or_JS)
-    smoldot_libraries(Rust_or_JS) --> Custom_Code(with_JSON_RPC_API)
-    Custom_Code(with_JSON_RPC_API) --> UI_dAPP
+    smoldot_libraries(Rust_or_JS) --> Custom_Code\n(with_JSON_RPC_API)
+    Custom_Code\n(with_JSON_RPC_API) --> UI_dAPP
 
 </diagram>
 


### PR DESCRIPTION
a) Remove from custom css a generic `line-height: 1.3;` that was breaking mermaidJS when double lines were used (`\n` );
e.g below

`before:`

![image](https://github.com/Polkadot-Blockchain-Academy/pba-content/assets/5408605/1214b273-2662-4730-8c45-2a41e15a4530)

`after:`
![image](https://github.com/Polkadot-Blockchain-Academy/pba-content/assets/5408605/932ad09b-d637-4d2f-a9bf-42d0acce31a2)

_Note: overall we should not generalize properties like that, as they can break many plugins_

b)  make width of `mermaidjs` to grow and fit our slides