### PR TITLE
Update Subsrate README.md

### DIFF
--- a/syllabus/5-Substrate/README.md
+++ b/syllabus/5-Substrate/README.md
@@ -1,47 +1,61 @@
-## Day 1 (Monday)
+# Substrate
 
-### Morning (~4 hours max)
+Total time required 2.5 days.
 
-- Introduction ✅ (60m)
-- Wasm Meta Protocol (90m)
-- Activity: Finding Runtime APIs and Host Functions in Substrate
+## Lesson Preperation
 
-### Afternoon (~4 hours max)
+This module consists of a combination of lectures, activities, and sections of the accompanying exercises to to students at what time.
+As there is a large amount of variance in student experience around Substrate, we want to make sure that we have a variety of content for students of different experience levels.
 
-- Show Me The Code (60m)
-- Substrate Interactions (60m)
-- FRAME-Less Activity (60m)
+### Graded Assignment
 
-> Graded assignments announced.
+> **All graded assignments and solutions must remain private to the Academy staff, faculty, and enrolled students!**
 
-## Day 2 (Tuesday)
+There is a private to the Academy graded exercise, in a _template repository_ titled `frameless-node-template--master` that should be introduced after the first lectures are complete.
+Instructors should \_create a per cohort, **private**, derived from the master copy, make it a template repo, and configure the cohort Github Classroom to use this new repo as an assignment.
 
-### Morning (~4 hours max)
+The "`px...` assignment problem" sections indicates that students are now capable of completing them with the content so far covered.
+They should be encouraged to start working on them as time allows _outside of class time!_
+They should not zone-out of class to complete this during class time, they should prioritize in-class activities and exercises over working on the assignment!
 
-- Transaction Pool (60m)
-- SCALE (60m)
-- Substrate/FRAME Tips and Tricks
+### Extercises and Activites
 
-### Afternoon (~4 hours max)
+There is a private to the Academy graded exercise, in a _template repository_ titled `pba-wasm-executor--master` that should be introduced after the first lectures are complete.
+Instructors should \_create a per cohort, **write-access granted to the cohort team**, derived from the master copy, make it a template repo, instruct students to use the `<github username/*` branch namespace for any of their work, with `<github username>` acting as their `main` branch.
+Ensure the `main` branch is _write procted, by required a PR first` - no one should be able to push to `main`!
 
-- FRAME-Less Activity
+## Lesson Schedule
 
-## Day 3 (Wednesday)
+### Day 1
 
-### Morning (~4 hours max)
+#### Morning
 
-- Substrate Storage (90m)
-- FRAME-Less Activity
+1. [Introduction](1-Intro_to_Substrate-slides.md) (60m)
+1. [WASM Meta Protocol](2-Substrate_WASM_Meta-slides.md) (90m)
+<!-- FIXME where is this? -->
+1. Activity: Finding Runtime APIs and Host Functions in Substrate
 
-### Afternoon (~4 hours max)
+#### Afternoon
 
-> Move to FRAME module
+1. [Show Me The Code](3-Substrate_Code-slides.md) (60m)
+1. [Substrate Interactions](4-Substrate-Interactions-slides.md) (60m)
+1. FRAME-Less Assignment (60m)
 
-## Reserve Ideas:
+### Day 2
 
-1. Activity: Substrate folder structure
-1. Activity: Wasm crate activity
-1. Lecture: Polkadot.js-API library
-1. Activity: Build a `sub-du`
-1. Activity: consensus by Joshy
-1. sub-xt
+#### Morning
+
+1. [Transaction Pool](5-Substrate_Transaction_Pool-slides.md) (60m)
+1. [SCALE](6-SCALE-slides.md) (60m)
+1. [Substrate and FRAME Tips and Tricks](7-Substrate_FRAME_Tips_Tricks-slides.md)
+
+#### Afternoon
+
+1. FRAME-Less Assignment
+
+### Day 3
+
+#### Morning
+
+1. [Substrate Storage](8-Substrate_Merklized_Storage-slides.md) (90m)
+1. FRAME-Less Assignment


### PR DESCRIPTION
This needs to be updated with the corrected new dir structure clobber by reversion of the #852 . Resolution on #855 likely blocks this from proceeding.

Closes #857 

Open Qs:

- [x] Can the WASM activity go public? If so, this PR should point to the public repo version, perhaps without the need for the `*--master` convention if we decide to push students to make a fork (from the template... but #600  will be a big PITA...) instead of using a common repo where patches and changes can be pushed real-time (and tagged per-cohort appropriately for reference) 