### PR TITLE
Fix remaining broken links

### DIFF
--- a/syllabus/1-Cryptography/README.md
+++ b/syllabus/1-Cryptography/README.md
@@ -51,15 +51,11 @@ They should not zone-out of class to complete this during class time, they shoul
 1. `p4_signing` assignment problem
 1. ☕ Break
 1. [6-Advanced_Signatures](6-Advanced_Signatures-slides.md)
-   <!-- FIXME move to separate MONO repo for crypto-->
-   - 💻 [AES Modes](./materials/aes-modes-activity/) Activity
 1. `p6_merkle` assignment problem
 
 #### Afternoon
 
 1. [7-Hash_Based_Data_Structures-slides](./7-Hash_Based_Data_Structures-slides.md)
-   <!-- FIXME move to separate MONO repo for crypto-->
-   - 💻 [Merkle Tree](./materials/merkle-tree-activity/) Activity
 1. `p5_data_integrity_and_recovery` assignment problem
 1. `p7_exotics` assignment problem if it exists
 1. ☕ Break

--- a/syllabus/3-Blockchain/5-Econ_and_Game_Theory_in_Blockchain_slides.md
+++ b/syllabus/3-Blockchain/5-Econ_and_Game_Theory_in_Blockchain_slides.md
@@ -873,7 +873,7 @@ So Bitcoin mining is in fact a huge coordination game and this is why honesty AK
 
 - More complex examples will be explored later in the forks lecture on Friday
 - Paper investigating PoW Nash Equilibrium and following the majority:
-  https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=7bf78054192d98e999edcdf08971a5eed42518d2
+   https://typeset.io/pdf/mining-pool-game-model-and-nash-equilibrium-analysis-for-pow-2lckzso542.pdf
 
 ---
 


### PR DESCRIPTION
This fixes the big issues from #904 and #903 

There may be followups in those issues like determining where the crypto activities were moved to, and deciding if we want to PoW paper in the repo.

But this very concretely makes the ci green and makes our repo broken-link free so I think it should go it.