### PR TITLE
Correcting "yarn start" to "yarn dev"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ corepack enable
 # Install Dependencies
 yarn
 # Run a slide server watching for file changes
-yarn start
+yarn dev
 ```
 
 This should open a new tab with a listing of all slide decks to choose from.


### PR DESCRIPTION
The docs were outdated, and gave the wrong command to serve slides.