### PR TITLE
Use Markdown Title Tags as Display Titles in the agenda view

### DIFF
--- a/extractSyllabus.ts
+++ b/extractSyllabus.ts
@@ -1,5 +1,33 @@
 const { globSync } = require('glob')
-const { writeFileSync } = require('fs')
+const { writeFileSync, readFileSync } = require('fs')
+
+const extractTitleFromMarkdown = (filePath: string): string => {
+  try {
+    const content = readFileSync(filePath, 'utf8')
+    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/)
+    
+    if (frontmatterMatch) {
+      const frontmatter = frontmatterMatch[1]
+      const titleMatch = frontmatter.match(/^title:\s*(.+)$/m)
+      if (titleMatch) {
+        return titleMatch[1].trim()
+      }
+    }
+  } catch (error) {
+    console.warn(`Warning: Could not read file ${filePath}:`, (error as Error).message)
+  }
+  
+  // Fallback to filename processing if no title found
+  const filename = filePath.split('/').pop() || ''
+  return filename
+    .replace('_slides.md', '')
+    .replace('_Slides.md', '')
+    .replace('-slides.md', '')
+    .replace('-Slides.md', '')
+    .replace(/\d+-(.+)/, '$1') // Remove leading numbers and dash
+    .replace(/-/g, ' ')
+    .replace(/_/g, ' ')
+}
 
 // Sorting based on the initial number (even if it is in a string)
 const sortArray = (arr: string[]) => {
@@ -30,27 +58,40 @@ const sortArray = (arr: string[]) => {
   return arr
 }
 
-const dirs = globSync('./syllabus/**/**/*lides.md', { ignore: ['node_modules/**', '**/README.md'] })
-const paths = sortArray(dirs).map((dir: any) =>
-  dir
-    .replace('syllabus/', '')
+const files = globSync('./syllabus/**/**/*lides.md', { ignore: ['node_modules/**', '**/README.md'] })
+const sortedFiles = sortArray([...files])
+
+const fileData: { [key: string]: string } = {}
+sortedFiles.forEach((filePath: string) => {
+  const relativePath = filePath.replace('./syllabus/', '')
+  const title = extractTitleFromMarkdown(filePath)
+  fileData[relativePath] = title
+})
+
+const parsed: any = {}
+Object.entries(fileData).forEach(([filePath, title]) => {
+  const pathWithoutExtension = filePath
     .replace('_slides.md', '')
     .replace('_Slides.md', '')
     .replace('-slides.md', '')
     .replace('-Slides.md', '')
-)
-
-const parsed: any = {}
-for (let i = 0; i < paths.length; i++) {
+  
   let position = parsed
-  const split = paths[i].split('/')
+  const split = pathWithoutExtension.split('/')
+  
   for (let j = 0; j < split.length; j++) {
     if (split[j] !== '') {
-      if (typeof position[split[j]] === 'undefined') position[split[j]] = {}
-      position = position[split[j]]
+      if (j === split.length - 1) {
+        position[split[j]] = title
+      } else {
+        if (typeof position[split[j]] === 'undefined') {
+          position[split[j]] = {}
+        }
+        position = position[split[j]]
+      }
     }
   }
-}
+})
 
-const data = JSON.stringify(parsed)
+const data = JSON.stringify(parsed, null, 2)
 writeFileSync('./src/syllabus.json', data)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export const App = () => {
         </menu>
       </header>
       <div className="accordion">
-        {Object.entries(someJson).map(r => <Accordion title={replaceText(r[0])} content={r[1]} path={"syllabus/" + r[0]}/>)}
+        {Object.entries(someJson.syllabus || someJson).map(r => <Accordion title={replaceText(r[0])} content={r[1]} path={"syllabus/" + r[0]}/>)}
       </div>
     </>
   )

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -20,8 +20,8 @@ export const Accordion = ({ title, content, path }: AccordionInterface) => {
       </div>
       {isActive && <div className="accordion-draw">{
         Object.entries(content).map(r => {
-          const text = replaceText(r[0])
-          if (Object.values(r[1])[0] === undefined) {
+          const text = typeof r[1] === 'string' ? r[1] : replaceText(r[0])
+          if (typeof r[1] === 'string') {
             return (
               <a href={path + "/" + r[0] + "-slides.html"}>
                 <div className="accordion-content">{text}</div>


### PR DESCRIPTION
https://polkadot-blockchain-academy.github.io/pba-content/current/index.html

Currently, each markdown file already has a proper title defined inside the file.  
This PR proposes switching the display title from the file name (left-hand side in the screenshot) to the markdown file’s internal title tag (right-hand side in the screenshot).


<img width="1442" height="429" alt="image" src="https://github.com/user-attachments/assets/4fd62471-b576-49c9-9389-e675fb72fe07" />
<img width="1437" height="551" alt="image" src="https://github.com/user-attachments/assets/62a33207-edbc-42ca-8407-6db5c43045e5" />
<img width="1442" height="779" alt="image" src="https://github.com/user-attachments/assets/d5b3d244-9646-49ce-a6d1-2314da6f30b7" />
<img width="1452" height="374" alt="image" src="https://github.com/user-attachments/assets/1971b417-b6ca-46bd-8c84-a2444c54f605" />
<img width="1447" height="234" alt="image" src="https://github.com/user-attachments/assets/9f558864-9060-4758-a8a3-942ec400549d" />
<img width="1445" height="259" alt="image" src="https://github.com/user-attachments/assets/a406fd8a-abd7-4ca3-930f-b9efd1b6ad44" />
