### PR TITLE
Adding guidelines for student projects

### DIFF
--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -60,9 +60,8 @@ Every student ships, **solo**, a project with exactly these components:
   - a **TUI** (ratatui, textual, ink, etc.), or
   - an **MCP server** (yes, this counts as a frontend - it is how an AI agent "drives" your backend; this category is hot right now and reviewers are paying attention to it).
 
-### 3.3 Mandatory integrations
+### 3.3 Mandatory integration
 
-- **Polkadot Desktop interaction.** Your project must include at least one meaningful interaction through Polkadot Desktop - signing, connecting, dispatching, whatever fits. This is non-negotiable.
 - **Web deploy on Bulletin Chain + DotNS.** Every project ships a web presence hosted on Bulletin Chain and reachable via a DotNS name. For web-app frontends, this *is* your app. For CLI++ frontends (TUI or MCP server), you still ship a web presence - at minimum a product / landing page describing what the project does, how to install it, and how to use it. No project is exempt. The point is that every student touches the decentralized deploy path end-to-end.
 
 ### 3.4 Scope rule

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -165,12 +165,37 @@ At the end of the program you hand in:
    - A README covering: what the project does, which path you picked, how to run it, what works, what doesn't, known limitations.
    - Meaningful commit history.
 2. **A working demo.** Live is preferred. A recorded fallback is always nice in case live is unsafe (e.g. testnet flakiness).
-3. **A 5-minute pitch / demo presentation** on pitch day. Short, sharp, honest.
+3. **A 5-minute pitch / demo presentation** on pitch day. See section 8 for what this should look like.
 4. **A retrospective write-up** using [`retrospective-template.md`](./retrospective-template.md). This is the short post-mortem where you tell us what worked, what broke, and - most importantly - **what you'd tell the Parity team about the stack based on what you hit**. Reviewers read this carefully. It is not busywork.
 
 ---
 
-## 8. Timeline
+## 8. Pitch Day (The 5-Minute Presentation)
+
+On the final day of the program, every student gives a short presentation. This is not a formality - it is how reviewers (and your peers) first encounter your work. Treat it as the front door to your project.
+
+### 8.1 Format
+
+- **5 minutes** for your pitch. Strict. Practice with a timer.
+- **Up to 2 extra minutes** afterward for questions from faculty and fellow students.
+- **Slides are expected.** A simple deck is fine - readable, focused, not overstuffed. No template is mandated; use whatever you like.
+- **A demo is expected.** Live is preferred. A recorded fallback is fine (and smart) if going live would be fragile - testnet flakiness, network issues, hardware quirks. Many strong pitches mix both.
+
+### 8.2 What to cover (roughly in this order)
+
+1. **The product.** What is it? In one sentence, then show us.
+2. **Why it's interesting / relevant.** Why did you pick this problem? Who is it for? Why does it belong on the Polkadot stack specifically?
+3. **The demo.** Walk through the thing working end-to-end - backend, frontend, decentralized deploy. This is the heart of the pitch. Spend time here.
+4. **Learnings, problems, and what broke.** The honest part. Sharp edges you hit on the stack, bug reports you filed, things that surprised you, things you'd do differently. Reviewers value this section more than you'd guess.
+5. **Next steps, future ideas, and feedback to the stack.** Where would you take this next? What's still rough? What should Parity know about the stack based on what you went through?
+
+### 8.3 Tone
+
+Short, sharp, honest. The worst pitches hide what broke and pad the demo with filler. The best ones leave a reviewer thinking *"I want to clone that repo and run it."* Aim for that.
+
+---
+
+## 9. Timeline
 
 Project time runs during the final portion of the 2-week PBP program. Exact dates and daily schedule are in the cohort's [`syllabus/`](../../syllabus/) schedule.
 
@@ -185,7 +210,7 @@ Rough shape:
 
 ---
 
-## 9. Process & Support
+## 10. Process & Support
 
 - **Office hours with faculty** are available throughout project time. Use them.
 - **If you are on a risky path and stuck, come talk to us early.** "I am 48 hours into this and I don't know if it's possible" is a normal conversation to have. Waiting until day 10 to raise it is not.
@@ -194,7 +219,7 @@ Rough shape:
 
 ---
 
-## 10. A Final Note
+## 11. A Final Note
 
 You are among the first cohorts building on the decentralized Polkadot app stack as a unified thing. A lot of what you find - good and bad - will directly shape how Parity builds this stack for the next few years. Take that seriously. Build something you would actually want to exist. Be honest about what happened. Have fun.
 

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -6,22 +6,22 @@ Read it end to end before you start. If something here is unclear or contradicts
 
 ---
 
-## 1. You Are Building on an Alpha Stack (Read This First)
+## 1. You Are Building on an ever evolving Stack (Read This First)
 
-The Polkadot stack you will build on - Pallets, PVM smart contracts, Bulletin Chain, Statement Store, DotNS, Polkadot Desktop - is **effectively in alpha**. It is real, it works, and it is also still very much under active development. Components ship weekly. Interfaces shift. Some things you expect to work will not work, and the answer will sometimes be "nobody has tried that yet."
+The Polkadot stack you will build on is ever evolving. Some of it like the Pallets are pretty battle tested, but new tech like - PVM smart contracts, Bulletin Chain, Statement Store, DotNS - is **effectively in alpha**. It is real, it works, and it is also still very much under active development. Components ship weekly. Interfaces shift. Some things you expect to work will not work, and the answer will sometimes be "nobody has tried that yet."
 
 This is not a warning so you can lower your ambition. It is a warning so you can **reframe what success looks like**.
 
-- **Hitting sharp edges is expected.** It is not a failure mode, it is a data point.
+- **Hitting sharp edges is expected.** Things are still a work in progress.
 - **Filing a precise, reproducible bug report against the stack is valued.** A good bug report can be worth as much as a working feature.
 - **Submitting a PR that fixes a stack issue you hit is valued highest of all.** It is the clearest possible signal you can give us.
 - **Honest "here is what I tried, here is where I got stuck, here is what I learned" beats a polished demo that hides what broke.**
 
-You are helping us discover the shape of the stack at the same time as you are building on it. That is the deal. Take it seriously and it will be one of the best things on your CV.
+You are helping us discover the shape of the stack at the same time as you are building on it.
 
 ### The vision you are building toward
 
-The Polkadot stack is reaching for a **fully decentralized application stack**: on-chain logic, decentralized storage (Bulletin Chain), verifiable name resolution (DotNS), local-first tooling (Polkadot Desktop), and frictionless deployment. The long-term goal is that an indie developer can ship a real product with no centralized dependencies and no gatekeepers. Your project is a concrete test of how close we are.
+The Polkadot stack is reaching for a **fully decentralized application stack**: on-chain logic, decentralized storage (Bulletin Chain), verifiable name resolution (DotNS), frictionless deployment and more that we wont use yet because its stil learly in the making. The long-term goal is that an indie developer can ship a real product with no centralized dependencies and no gatekeepers. Your project is a concrete test of how close we are.
 
 ---
 
@@ -66,7 +66,7 @@ Every student ships, **solo**, a project with exactly these components:
 
 ### 3.4 Scope rule
 
-The backend + frontend combo is a **strict requirement**, not a default. Pure-infra projects (an indexer, a bridge, a standalone library) do not satisfy the rubric on their own. If you think you have a good reason to deviate, talk to faculty *before* you start building.
+The backend + frontend combo is a **strict requirement**. Pure-infra projects (an indexer, a bridge, a standalone library) do not satisfy the rubric on their own. If you think you have a good reason to deviate, talk to faculty *before* you start building.
 
 ---
 
@@ -79,14 +79,13 @@ The stack is not equally solid in every corner. You get to pick any valid combin
 | Pallet | Web / CLI++ | **~100%** | Well-trodden path, full curriculum support, plenty of prior work to crib from. |
 | Solidity on EVM | Web / CLI++ | **~90%** | Mature tooling, standard ecosystem, mostly-solved problems. Only issues will be if your contracts use really advanced gas optimisation/manipulation. |
 | Solidity on PVM | Web / CLI++ | **~70%** | Expect toolchain quirks. It is technically more optimized than EVM but the compiler struggles with big/complex contracts. |
-| Rust smart contract on PVM | Web / CLI++ | **~50%** | Bleeding edge. Real chance you hit walls nobody has hit yet. Its still early in its development. |
+| Rust smart contract on PVM | Web / CLI++ | **~50%** | Bleeding edge. Real chance you hit walls nobody has hit yet. Its still early in its development and not many people have built with it. |
 
 **Read this carefully:**
 
 - These numbers are **advisory**, not prescriptive. You may pick any row. No faculty sign-off is required for the riskier paths - but we *strongly* recommend talking to us if you go for one.
-- Riskier paths are **higher ceiling**. If you ship a Rust-contract-on-PVM project that actually works, reviewers will notice. Hard.
-- Riskier paths are **higher floor risk**. If you choose the bottom row and get stuck for five days, that is a real outcome - you need to decide whether that trade is worth it for *you*.
-- **Getting stuck is not failure as long as you document it well.** A Rust-on-PVM project that couldn't fully ship but contains two solid bug reports and a PR against the stack is a legitimate deliverable. Plan for that possibility if you pick a risky path.
+- Riskier paths are **higher ceiling**. If you ship a Rust-contract-on-PVM project that actually works, it will help us making sure that the stack works and is getting more mature.
+- **Getting stuck is not failure as long as you document it well.** A Rust-on-PVM project that couldn't fully ship but contains two solid bug reports and a PR against the stack is a legitimate deliverable. Plan for that possibility if you pick a risky path. We truly value help in improving the stack.
 
 ---
 
@@ -99,6 +98,7 @@ These are the things that raise your ceiling beyond "built the required thing." 
 - **PRs to fix stack issues** you hit. Even small ones. This is the strongest possible signal to reviewers.
 - **Protocol ports** - take something interesting from another chain (x402 payments, encrypted/anonymous chat, decentralized file hosting, something else) and bring it to Polkadot.
 - **Projects that gesture at Parity's broader vision** - games, decentralized collaboration tools, things that feel like the stack growing into its promise.
+- **Any tooling to help others build projects** - skills.md files or any other tool reusable by other people to make them ship faster is always appreciated.
 
 ---
 
@@ -154,9 +154,10 @@ These are the tells. Do not let them show up in your repo.
 
 At your 5-minute demo, we may ask you: *"walk me through this file - why is it structured this way?"* You need to be able to answer that question about any file in your repo. If you cannot, you did not ship it - the AI did, and you just pushed it.
 
-### 6.6 Docs and prose: the same rules, harder
+### 6.6 AI in ReadMe
 
-The "no slop" rule is not just about code. It applies just as hard - maybe harder - to prose. README, code comments, the retrospective, your pitch script. AI-generated prose is faster to produce than code, harder to spot at a glance, and ten times more likely to make it through unread.
+The "no slop" rule is not just about code. It applies even harder - to prose. 
+In particular to your README. AI-generated prose is faster to produce than code, harder to spot at a glance, and ten times more likely to make it through unread.
 
 A few things to internalise:
 
@@ -164,9 +165,6 @@ A few things to internalise:
 - **A wall of confident-sounding text is slop, even if every sentence is technically correct.** Reviewers can feel the difference between a README written by someone who built the thing and one assembled out of prompts. So can your peers.
 - **Rule of thumb for your README: 90% you, 10% AI.** Use AI for grammar, spelling, formatting cleanup, maybe rephrasing a clunky paragraph. Do **not** use it to draft the document. The structure, the framing, the choices about what to include and what to cut - those need to be yours. Same for the retrospective.
 - **If you expect us to read it, you should have read it yourself. Twice.** End to end. Out loud, even. If you can't be bothered, neither can we, and we will notice.
-- **Same applies to comments in code.** Comments that restate *what* the code does are noise that AI will happily generate by the bucket. Comments that explain *why* something is the way it is - the constraint, the trade-off, the bug you worked around - are the only kind worth committing.
-
-If your README, retrospective, or pitch script reads like it was generated, it will be obvious, and it will count against you more than if you had written something rougher and shorter by hand.
 
 ---
 

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -154,6 +154,20 @@ These are the tells. Do not let them show up in your repo.
 
 At your 5-minute demo, we may ask you: *"walk me through this file - why is it structured this way?"* You need to be able to answer that question about any file in your repo. If you cannot, you did not ship it - the AI did, and you just pushed it.
 
+### 6.6 Docs and prose: the same rules, harder
+
+The "no slop" rule is not just about code. It applies just as hard - maybe harder - to prose. README, code comments, the retrospective, your pitch script. AI-generated prose is faster to produce than code, harder to spot at a glance, and ten times more likely to make it through unread.
+
+A few things to internalise:
+
+- **Humans read every word you ship.** AI generates them in seconds; we read them in minutes. A 4000-word README that nobody asked for is not "thorough" - it is wasting reviewer time. Length is not a virtue. Density and honesty are.
+- **A wall of confident-sounding text is slop, even if every sentence is technically correct.** Reviewers can feel the difference between a README written by someone who built the thing and one assembled out of prompts. So can your peers.
+- **Rule of thumb for your README: 90% you, 10% AI.** Use AI for grammar, spelling, formatting cleanup, maybe rephrasing a clunky paragraph. Do **not** use it to draft the document. The structure, the framing, the choices about what to include and what to cut - those need to be yours. Same for the retrospective.
+- **If you expect us to read it, you should have read it yourself. Twice.** End to end. Out loud, even. If you can't be bothered, neither can we, and we will notice.
+- **Same applies to comments in code.** Comments that restate *what* the code does are noise that AI will happily generate by the bucket. Comments that explain *why* something is the way it is - the constraint, the trade-off, the bug you worked around - are the only kind worth committing.
+
+If your README, retrospective, or pitch script reads like it was generated, it will be obvious, and it will count against you more than if you had written something rougher and shorter by hand.
+
 ---
 
 ## 7. Deliverables
@@ -162,26 +176,58 @@ At the end of the program you hand in:
 
 1. **A GitHub repo** with:
    - Working code (backend + frontend).
-   - A README covering: what the project does, which path you picked, how to run it, what works, what doesn't, known limitations.
+   - A README covering: what the project does, which path you picked, how to run it end-to-end, what works, what doesn't, known limitations, design decisions and compromises you made (and would revisit), and the URL of your decentralized deployment.
    - Meaningful commit history.
 2. **A working demo.** Live is preferred. A recorded fallback is always nice in case live is unsafe (e.g. testnet flakiness).
-3. **A 5-minute pitch / demo presentation** on pitch day. See section 8 for what this should look like.
+3. **A 5-minute pitch / demo presentation** on pitch day. See section 9 for what this should look like.
 4. **A retrospective write-up** using [`retrospective-template.md`](./retrospective-template.md). This is the short post-mortem where you tell us what worked, what broke, and - most importantly - **what you'd tell the Parity team about the stack based on what you hit**. Reviewers read this carefully. It is not busywork.
 
 ---
 
-## 8. Pitch Day (The 5-Minute Presentation)
+## 8. Before You Submit
+
+A final pass before you push your last commit. None of this is busywork - every item here is a thing reviewers will notice if you skip it. Run this list at end-of-day on day 12, not the morning of pitch day.
+
+### 8.1 Code
+
+- **It builds.** Clean build, no errors, no warnings. If you have warnings you can't kill, document why in the README.
+- **Tests pass.** The full suite, not just the one you wrote last.
+- **No dead code.** Remove unused functions, storage items, events, errors, scaffolding from earlier directions you abandoned.
+- **No "example" cruft.** If you started from a template, strip the parts you didn't use.
+- **Formatted.** Run your language's standard formatter (`cargo +nightly fmt`, `prettier`, `gofmt`, whatever applies).
+- **No code that can panic on the happy path.** Tests and benchmarks are fine. Production paths are not.
+- **Documented where it isn't obvious.** Comments explain *why*, not *what*. Note the compromises and TODOs you'd revisit.
+
+### 8.2 Repo
+
+- **Meaningful git history.** Reviewers will read your commits. `fix`, `wip`, `more` ten times in a row is a red flag (see section 6.4).
+- **README at the repo root**, covering everything listed in section 7 deliverable 1. Include the Bulletin Chain / DotNS URL of your deployment so reviewers can click straight through.
+- **Retrospective filled in** using [`retrospective-template.md`](./retrospective-template.md). Don't leave this for the morning of pitch day.
+
+### 8.3 Deployment
+
+- **Decentralized deploy is live and reachable** at your DotNS name (see section 3.3). If it isn't, reviewers can't see your work. Test it from a fresh browser session - not the one you've been developing in.
+
+### 8.4 Demo
+
+- **Live demo dry-run.** Run it end-to-end at least once on the network you'll use on pitch day. Have a recorded fallback ready in case the live version flakes (see section 9).
+
+If any of these is "I'll get to it tomorrow" the night before pitch day, you've already lost time.
+
+---
+
+## 9. Pitch Day (The 5-Minute Presentation)
 
 On the final day of the program, every student gives a short presentation. This is not a formality - it is how reviewers (and your peers) first encounter your work. Treat it as the front door to your project.
 
-### 8.1 Format
+### 9.1 Format
 
 - **5 minutes** for your pitch. Strict. Practice with a timer.
 - **Up to 2 extra minutes** afterward for questions from faculty and fellow students.
 - **Slides are expected.** A simple deck is fine - readable, focused, not overstuffed. No template is mandated; use whatever you like.
 - **A demo is expected.** Live is preferred. A recorded fallback is fine (and smart) if going live would be fragile - testnet flakiness, network issues, hardware quirks. Many strong pitches mix both.
 
-### 8.2 What to cover (roughly in this order)
+### 9.2 What to cover (roughly in this order)
 
 1. **The product.** What is it? In one sentence, then show us.
 2. **Why it's interesting / relevant.** Why did you pick this problem? Who is it for? Why does it belong on the Polkadot stack specifically?
@@ -189,13 +235,13 @@ On the final day of the program, every student gives a short presentation. This 
 4. **Learnings, problems, and what broke.** The honest part. Sharp edges you hit on the stack, bug reports you filed, things that surprised you, things you'd do differently. Reviewers value this section more than you'd guess.
 5. **Next steps, future ideas, and feedback to the stack.** Where would you take this next? What's still rough? What should Parity know about the stack based on what you went through?
 
-### 8.3 Tone
+### 9.3 Tone
 
 Short, sharp, honest. The worst pitches hide what broke and pad the demo with filler. The best ones leave a reviewer thinking *"I want to clone that repo and run it."* Aim for that.
 
 ---
 
-## 9. Timeline
+## 10. Timeline
 
 Project time runs during the final portion of the 2-week PBP program. Exact dates and daily schedule are in the cohort's [`syllabus/`](../../syllabus/) schedule.
 
@@ -208,7 +254,7 @@ Rough shape:
 
 ---
 
-## 10. Process & Support
+## 11. Process & Support
 
 - **Office hours with faculty** are available throughout project time. Use them.
 - **If you are on a risky path and stuck, come talk to us early.** "I am 48 hours into this and I don't know if it's possible" is a normal conversation to have. Waiting until day 10 to raise it is not.
@@ -217,7 +263,7 @@ Rough shape:
 
 ---
 
-## 11. A Final Note
+## 12. A Final Note
 
 You are among the first cohorts building on the decentralized Polkadot app stack as a unified thing. A lot of what you find - good and bad - will directly shape how Parity builds this stack for the next few years. Take that seriously. Build something you would actually want to exist. Be honest about what happened. Have fun.
 

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -206,8 +206,6 @@ Rough shape:
 - **Week 2**: build, break, report, fix.
 - **Final day**: pitch day.
 
-**Plan your scope for two weeks, not four.** It is far better to ship a small thing that works than a large thing that half-works.
-
 ---
 
 ## 10. Process & Support

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -62,11 +62,11 @@ Every student ships, **solo**, a project with exactly these components:
 
 ### 3.3 Mandatory integration
 
-- **Web deploy on Bulletin Chain + DotNS.** Every project ships a web presence hosted on Bulletin Chain and reachable via a DotNS name. For web-app frontends, this *is* your app. For CLI++ frontends (TUI or MCP server), you still ship a web presence - at minimum a product / landing page describing what the project does, how to install it, and how to use it. No project is exempt. The point is that every student touches the decentralized deploy path end-to-end.
+- **Web deploy on Bulletin Chain + DotNS.** Every project ships a web presence hosted on Bulletin Chain and reachable via a DotNS name. For web-app frontends, this _is_ your app. For CLI++ frontends (TUI or MCP server), you still ship a web presence - at minimum a product / landing page describing what the project does, how to install it, and how to use it. No project is exempt. The point is that every student touches the decentralized deploy path end-to-end.
 
 ### 3.4 Scope rule
 
-The backend + frontend combo is a **strict requirement**. Pure-infra projects (an indexer, a bridge, a standalone library) do not satisfy the rubric on their own. If you think you have a good reason to deviate, talk to faculty *before* you start building.
+The backend + frontend combo is a **strict requirement**. Pure-infra projects (an indexer, a bridge, a standalone library) do not satisfy the rubric on their own. If you think you have a good reason to deviate, talk to faculty _before_ you start building.
 
 ---
 
@@ -74,16 +74,16 @@ The backend + frontend combo is a **strict requirement**. Pure-infra projects (a
 
 The stack is not equally solid in every corner. You get to pick any valid combination of backend and frontend - this matrix tells you how likely it is to actually work end-to-end in two weeks.
 
-| Backend | Frontend | Confidence it ships | Notes |
-|---|---|---|---|
-| Pallet | Web / CLI++ | **~100%** | Well-trodden path, full curriculum support, plenty of prior work to crib from. |
-| Solidity on EVM | Web / CLI++ | **~90%** | Mature tooling, standard ecosystem, mostly-solved problems. Only issues will be if your contracts use really advanced gas optimisation/manipulation. |
-| Solidity on PVM | Web / CLI++ | **~70%** | Expect toolchain quirks. It is technically more optimized than EVM but the compiler struggles with big/complex contracts. |
-| Rust smart contract on PVM | Web / CLI++ | **~50%** | Bleeding edge. Real chance you hit walls nobody has hit yet. Its still early in its development and not many people have built with it. |
+| Backend                    | Frontend    | Confidence it ships | Notes                                                                                                                                                |
+| -------------------------- | ----------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pallet                     | Web / CLI++ | **~100%**           | Well-trodden path, full curriculum support, plenty of prior work to crib from.                                                                       |
+| Solidity on EVM            | Web / CLI++ | **~90%**            | Mature tooling, standard ecosystem, mostly-solved problems. Only issues will be if your contracts use really advanced gas optimisation/manipulation. |
+| Solidity on PVM            | Web / CLI++ | **~70%**            | Expect toolchain quirks. It is technically more optimized than EVM but the compiler struggles with big/complex contracts.                            |
+| Rust smart contract on PVM | Web / CLI++ | **~50%**            | Bleeding edge. Real chance you hit walls nobody has hit yet. Its still early in its development and not many people have built with it.              |
 
 **Read this carefully:**
 
-- These numbers are **advisory**, not prescriptive. You may pick any row. No faculty sign-off is required for the riskier paths - but we *strongly* recommend talking to us if you go for one.
+- These numbers are **advisory**, not prescriptive. You may pick any row. No faculty sign-off is required for the riskier paths - but we _strongly_ recommend talking to us if you go for one.
 - Riskier paths are **higher ceiling**. If you ship a Rust-contract-on-PVM project that actually works, it will help us making sure that the stack works and is getting more mature.
 - **Getting stuck is not failure as long as you document it well.** A Rust-on-PVM project that couldn't fully ship but contains two solid bug reports and a PR against the stack is a legitimate deliverable. Plan for that possibility if you pick a risky path. We truly value help in improving the stack.
 
@@ -114,7 +114,7 @@ You are the engineer. The AI is a tool. The fact that a tool produced the code d
 
 - Does it work?
 - Do you understand it?
-- Is it correct *in your project's context*?
+- Is it correct _in your project's context_?
 - Can you explain it to a reviewer at demo?
 
 If the answer to any of those is "no," do not commit it.
@@ -128,15 +128,17 @@ If the answer to any of those is "no," do not commit it.
 ### 6.3 Good vs. bad examples
 
 **Good:**
+
 - "I used Claude to scaffold the XCM message format, then manually verified the encoding against the spec and added a round-trip test."
 - "My MCP server handler was AI-drafted. I rewrote the auth path after reading how the session store actually works."
 - "I let Cursor generate boilerplate for the React forms, then hand-wrote the signing flow because the generated version called an API that doesn't exist."
 - "Couldn't get the contract compiling. Had Claude explain three possible causes, tested each, found the real one was a linker flag."
 
 **Bad:**
+
 - Copy-pasting 400 lines of generated pallet code, not running it, and watching it break at demo.
 - Commit message: `fix stuff` on a 2000-line AI diff.
-- Accepting an AI fix "because it compiled" without understanding *why* it compiled.
+- Accepting an AI fix "because it compiled" without understanding _why_ it compiled.
 - Generated tests that assert `true == true` and exercise nothing.
 
 ### 6.4 Red flags reviewers will catch
@@ -152,11 +154,11 @@ These are the tells. Do not let them show up in your repo.
 
 ### 6.5 What "ownership" means in practice
 
-At your 5-minute demo, we may ask you: *"walk me through this file - why is it structured this way?"* You need to be able to answer that question about any file in your repo. If you cannot, you did not ship it - the AI did, and you just pushed it.
+At your 5-minute demo, we may ask you: _"walk me through this file - why is it structured this way?"_ You need to be able to answer that question about any file in your repo. If you cannot, you did not ship it - the AI did, and you just pushed it.
 
 ### 6.6 AI in ReadMe
 
-The "no slop" rule is not just about code. It applies even harder - to prose. 
+The "no slop" rule is not just about code. It applies even harder - to prose.
 In particular to your README. AI-generated prose is faster to produce than code, harder to spot at a glance, and ten times more likely to make it through unread.
 
 A few things to internalise:
@@ -194,7 +196,7 @@ A final pass before you push your last commit. None of this is busywork - every 
 - **No "example" cruft.** If you started from a template, strip the parts you didn't use.
 - **Formatted.** Run your language's standard formatter (`cargo +nightly fmt`, `prettier`, `gofmt`, whatever applies).
 - **No code that can panic on the happy path.** Tests and benchmarks are fine. Production paths are not.
-- **Documented where it isn't obvious.** Comments explain *why*, not *what*. Note the compromises and TODOs you'd revisit.
+- **Documented where it isn't obvious.** Comments explain _why_, not _what_. Note the compromises and TODOs you'd revisit.
 
 ### 8.2 Repo
 
@@ -235,7 +237,7 @@ On the final day of the program, every student gives a short presentation. This 
 
 ### 9.3 Tone
 
-Short, sharp, honest. The worst pitches hide what broke and pad the demo with filler. The best ones leave a reviewer thinking *"I want to clone that repo and run it."* Aim for that.
+Short, sharp, honest. The worst pitches hide what broke and pad the demo with filler. The best ones leave a reviewer thinking _"I want to clone that repo and run it."_ Aim for that.
 
 ---
 

--- a/projects/PBP-Lisbon-2026/project-guidelines.md
+++ b/projects/PBP-Lisbon-2026/project-guidelines.md
@@ -1,0 +1,202 @@
+# PBP Lisbon 2026 - Project Guidelines
+
+Welcome to the project phase of the Polkadot **Protocol Builders Program**. This document tells you what to build, how you will be evaluated, and how to make the most of two weeks on a stack that is still being shaped.
+
+Read it end to end before you start. If something here is unclear or contradicts what a faculty member told you, ask - this is a living document.
+
+---
+
+## 1. You Are Building on an Alpha Stack (Read This First)
+
+The Polkadot stack you will build on - Pallets, PVM smart contracts, Bulletin Chain, Statement Store, DotNS, Polkadot Desktop - is **effectively in alpha**. It is real, it works, and it is also still very much under active development. Components ship weekly. Interfaces shift. Some things you expect to work will not work, and the answer will sometimes be "nobody has tried that yet."
+
+This is not a warning so you can lower your ambition. It is a warning so you can **reframe what success looks like**.
+
+- **Hitting sharp edges is expected.** It is not a failure mode, it is a data point.
+- **Filing a precise, reproducible bug report against the stack is valued.** A good bug report can be worth as much as a working feature.
+- **Submitting a PR that fixes a stack issue you hit is valued highest of all.** It is the clearest possible signal you can give us.
+- **Honest "here is what I tried, here is where I got stuck, here is what I learned" beats a polished demo that hides what broke.**
+
+You are helping us discover the shape of the stack at the same time as you are building on it. That is the deal. Take it seriously and it will be one of the best things on your CV.
+
+### The vision you are building toward
+
+The Polkadot stack is reaching for a **fully decentralized application stack**: on-chain logic, decentralized storage (Bulletin Chain), verifiable name resolution (DotNS), local-first tooling (Polkadot Desktop), and frictionless deployment. The long-term goal is that an indie developer can ship a real product with no centralized dependencies and no gatekeepers. Your project is a concrete test of how close we are.
+
+---
+
+## 2. Hiring Reality Check
+
+There are **no grades** in PBP. Instead, **your project will be reviewed directly by Parity for hiring consideration**.
+
+This matters more than a grade would. A grade is a line in a transcript. A project is a thing a hiring manager can read, run, and argue about. Some of you will be talking to Parity about roles because of what you ship here.
+
+What reviewers will look for:
+
+- **Taste.** Did you choose a problem worth solving? Is your scope sane?
+- **Shipping discipline.** Does the repo run? Is the README honest about what works and what doesn't?
+- **Judgment under uncertainty.** When you got stuck, how did you reason about it? Did you pick a good next move?
+- **Honesty.** Hiding what broke is worse than reporting it clearly.
+- **Cleanliness.** Readable code. Meaningful commits. Not a dump.
+- **Voice.** We can tell when a README was written by a human who understood the project. We can also tell when it wasn't.
+
+---
+
+## 3. What You Will Build (Hard Requirements)
+
+Every student ships, **solo**, a project with exactly these components:
+
+### 3.1 One backend component (pick one)
+
+- **Substrate Pallet**
+- **Solidity smart contract on EVM**
+- **Solidity smart contract on PVM**
+- **Rust smart contract on PVM**
+
+### 3.2 One frontend component (pick one)
+
+- **Web app** (React, Svelte, Vue, whatever).
+- **CLI++** - a command-line frontend, but with ambition. A bare `clap`-style CLI on its own is **not enough** for this rubric. To count as CLI++, you must elevate it into one of:
+  - a **TUI** (ratatui, textual, ink, etc.), or
+  - an **MCP server** (yes, this counts as a frontend - it is how an AI agent "drives" your backend; this category is hot right now and reviewers are paying attention to it).
+
+### 3.3 Mandatory integrations
+
+- **Polkadot Desktop interaction.** Your project must include at least one meaningful interaction through Polkadot Desktop - signing, connecting, dispatching, whatever fits. This is non-negotiable.
+- **Web deploy on Bulletin Chain + DotNS.** Every project ships a web presence hosted on Bulletin Chain and reachable via a DotNS name. For web-app frontends, this *is* your app. For CLI++ frontends (TUI or MCP server), you still ship a web presence - at minimum a product / landing page describing what the project does, how to install it, and how to use it. No project is exempt. The point is that every student touches the decentralized deploy path end-to-end.
+
+### 3.4 Scope rule
+
+The backend + frontend combo is a **strict requirement**, not a default. Pure-infra projects (an indexer, a bridge, a standalone library) do not satisfy the rubric on their own. If you think you have a good reason to deviate, talk to faculty *before* you start building.
+
+---
+
+## 4. Path Certainty Matrix (Advisory)
+
+The stack is not equally solid in every corner. You get to pick any valid combination of backend and frontend - this matrix tells you how likely it is to actually work end-to-end in two weeks.
+
+| Backend | Frontend | Confidence it ships | Notes |
+|---|---|---|---|
+| Pallet | Web / CLI++ | **~100%** | Well-trodden path, full curriculum support, plenty of prior work to crib from. |
+| Solidity on EVM | Web / CLI++ | **~90%** | Mature tooling, standard ecosystem, mostly-solved problems. Only issues will be if your contracts use really advanced gas optimisation/manipulation. |
+| Solidity on PVM | Web / CLI++ | **~70%** | Expect toolchain quirks. It is technically more optimized than EVM but the compiler struggles with big/complex contracts. |
+| Rust smart contract on PVM | Web / CLI++ | **~50%** | Bleeding edge. Real chance you hit walls nobody has hit yet. Its still early in its development. |
+
+**Read this carefully:**
+
+- These numbers are **advisory**, not prescriptive. You may pick any row. No faculty sign-off is required for the riskier paths - but we *strongly* recommend talking to us if you go for one.
+- Riskier paths are **higher ceiling**. If you ship a Rust-contract-on-PVM project that actually works, reviewers will notice. Hard.
+- Riskier paths are **higher floor risk**. If you choose the bottom row and get stuck for five days, that is a real outcome - you need to decide whether that trade is worth it for *you*.
+- **Getting stuck is not failure as long as you document it well.** A Rust-on-PVM project that couldn't fully ship but contains two solid bug reports and a PR against the stack is a legitimate deliverable. Plan for that possibility if you pick a risky path.
+
+---
+
+## 5. Bonus Dimensions
+
+These are the things that raise your ceiling beyond "built the required thing." None are mandatory. All are noticed.
+
+- **Sensible use of Bulletin Chain / Statement Store in the project itself** - not just as website hosting. If storage or statements are part of your product's logic, that counts.
+- **High-quality bug reports** filed against the stack while you build. Precise, reproducible, with minimal repro code.
+- **PRs to fix stack issues** you hit. Even small ones. This is the strongest possible signal to reviewers.
+- **Protocol ports** - take something interesting from another chain (x402 payments, encrypted/anonymous chat, decentralized file hosting, something else) and bring it to Polkadot.
+- **Projects that gesture at Parity's broader vision** - games, decentralized collaboration tools, things that feel like the stack growing into its promise.
+
+---
+
+## 6. AI Usage Policy ("No Slop")
+
+**TL;DR: AI is allowed and encouraged. You own every line you ship. "The AI wrote it" is not a defense at demo.**
+
+We expect most of you to use AI tools heavily. Claude, Cursor, Copilot, Codex, whatever. That is fine - great, even. AI is part of how software is built in 2026, and using it well is a real skill. This section is about using it well.
+
+### 6.1 Core stance
+
+You are the engineer. The AI is a tool. The fact that a tool produced the code does not transfer responsibility for it - you are still on the hook for:
+
+- Does it work?
+- Do you understand it?
+- Is it correct *in your project's context*?
+- Can you explain it to a reviewer at demo?
+
+If the answer to any of those is "no," do not commit it.
+
+### 6.2 Responsibilities
+
+- **Read every diff before you commit it.** Every line.
+- **Test what you generate.** If you can't explain it, you can't commit it.
+- **Prefer small verified steps to large unreviewed dumps.** A 50-line AI-generated patch you understand is worth more than a 500-line one you don't.
+
+### 6.3 Good vs. bad examples
+
+**Good:**
+- "I used Claude to scaffold the XCM message format, then manually verified the encoding against the spec and added a round-trip test."
+- "My MCP server handler was AI-drafted. I rewrote the auth path after reading how the session store actually works."
+- "I let Cursor generate boilerplate for the React forms, then hand-wrote the signing flow because the generated version called an API that doesn't exist."
+- "Couldn't get the contract compiling. Had Claude explain three possible causes, tested each, found the real one was a linker flag."
+
+**Bad:**
+- Copy-pasting 400 lines of generated pallet code, not running it, and watching it break at demo.
+- Commit message: `fix stuff` on a 2000-line AI diff.
+- Accepting an AI fix "because it compiled" without understanding *why* it compiled.
+- Generated tests that assert `true == true` and exercise nothing.
+
+### 6.4 Red flags reviewers will catch
+
+These are the tells. Do not let them show up in your repo.
+
+- **Hallucinated API calls** - functions, flags, or crate methods that do not exist.
+- **Inconsistent naming across files** - `userId` in one file, `user_id` in the next, `uid` in a third, because different prompts produced different conventions.
+- **Code that doesn't compile** but was committed anyway.
+- **Tests that don't test** - fixtures with no assertions, or assertions that tautologically hold.
+- **Stale comments** describing code that was later rewritten.
+- **Commits with no narrative** - ten commits in a row titled `update`, `fix`, `more`, `wip`.
+
+### 6.5 What "ownership" means in practice
+
+At your 5-minute demo, we may ask you: *"walk me through this file - why is it structured this way?"* You need to be able to answer that question about any file in your repo. If you cannot, you did not ship it - the AI did, and you just pushed it.
+
+---
+
+## 7. Deliverables
+
+At the end of the program you hand in:
+
+1. **A GitHub repo** with:
+   - Working code (backend + frontend).
+   - A README covering: what the project does, which path you picked, how to run it, what works, what doesn't, known limitations.
+   - Meaningful commit history.
+2. **A working demo.** Live is preferred. A recorded fallback is always nice in case live is unsafe (e.g. testnet flakiness).
+3. **A 5-minute pitch / demo presentation** on pitch day. Short, sharp, honest.
+4. **A retrospective write-up** using [`retrospective-template.md`](./retrospective-template.md). This is the short post-mortem where you tell us what worked, what broke, and - most importantly - **what you'd tell the Parity team about the stack based on what you hit**. Reviewers read this carefully. It is not busywork.
+
+---
+
+## 8. Timeline
+
+Project time runs during the final portion of the 2-week PBP program. Exact dates and daily schedule are in the cohort's [`syllabus/`](../../syllabus/) schedule.
+
+Rough shape:
+
+- **Week 1**: lectures, exercises, pick your idea, talk to faculty, start scaffolding.
+- **End of week 1**: project kickoff - you should be building in earnest.
+- **Week 2**: build, break, report, fix.
+- **Final day**: pitch day.
+
+**Plan your scope for two weeks, not four.** It is far better to ship a small thing that works than a large thing that half-works.
+
+---
+
+## 9. Process & Support
+
+- **Office hours with faculty** are available throughout project time. Use them.
+- **If you are on a risky path and stuck, come talk to us early.** "I am 48 hours into this and I don't know if it's possible" is a normal conversation to have. Waiting until day 10 to raise it is not.
+- **Project ideas**: see [`../ideas.md`](../ideas.md) for a living idea bank. You are free to invent your own, or pick from the bank and make it yours.
+- **Bug reports against the stack**: faculty will point you at the right repos (Substrate, PVM, Bulletin Chain, Polkadot Desktop) during week 1. When in doubt, ask before filing.
+
+---
+
+## 10. A Final Note
+
+You are among the first cohorts building on the decentralized Polkadot app stack as a unified thing. A lot of what you find - good and bad - will directly shape how Parity builds this stack for the next few years. Take that seriously. Build something you would actually want to exist. Be honest about what happened. Have fun.
+
+Good luck.

--- a/projects/PBP-Lisbon-2026/resources.md
+++ b/projects/PBP-Lisbon-2026/resources.md
@@ -1,0 +1,73 @@
+# PBP Lisbon 2026 - Project Resources
+
+A curated starting set for your project phase. Not exhaustive. If you find
+something better than what's listed here, open a PR - this file is meant to
+evolve with the cohort.
+
+Sections mirror the paths in [`project-guidelines.md`](./project-guidelines.md) §3:
+pick a backend, pick a frontend, deploy on Bulletin Chain + DotNS.
+
+---
+
+## Starter templates
+
+- [`polkadot-stack-template`](https://github.com/shawntabrizi/polkadot-stack-template) - opinionated backend + web frontend starter from Shawn.
+- [`polkadot-sdk-minimal-template`](https://github.com/paritytech/polkadot-sdk-minimal-template) - the smallest viable Substrate runtime.
+- [`pba-omni-node`](https://github.com/kianenigma/pba-omni-node) - generic node that runs your custom runtime without you writing node-side code.
+
+## Backend: Substrate Pallet
+
+- [`paritytech/polkadot-sdk`](https://github.com/paritytech/polkadot-sdk) - the monorepo: Substrate, FRAME, Cumulus, Polkadot.
+- [Polkadot SDK docs](https://docs.polkadot.com/) - official docs portal for the SDK.
+- [Substrate Stack Exchange](https://substrate.stackexchange.com/) - Q&A site, actively answered.
+- [`frame-metadata`](https://github.com/paritytech/frame-metadata) - the on-chain metadata format.
+
+## Backend: Solidity on EVM or PVM
+
+- [Polkadot smart-contract tutorials](https://docs.polkadot.com/tutorials/smart-contracts/) - official walkthroughs for Solidity on Polkadot.
+- [`paritytech/revive`](https://github.com/paritytech/revive) - Solidity → PVM compiler.
+- [Foundry](https://book.getfoundry.sh/) - modern Solidity dev/test toolchain.
+- [Hardhat](https://hardhat.org/) - alternative Solidity toolchain with rich JS/TS integration.
+
+## Backend: Rust contracts on PVM (RevX)
+
+> Bleeding-edge path - see guidelines §4. RevX is in open beta. Budget time
+> for sharp edges and plan for a strong bug report as a legitimate deliverable.
+> Note: this path uses **RevX**, not ink!.
+
+- [RevX](https://revx.dev/) - Rust smart-contract IDE for Polkadot.
+
+## Frontend: chain interaction libraries
+
+- [PAPI (`papi.how`)](https://papi.how/) - modern, type-safe TypeScript client for Polkadot chains.
+- [PAPI metadata explorer](https://dev.papi.how/explorer) - interactive explorer for any chain's metadata.
+- [polkadot.js API](https://polkadot.js.org/docs/) - older TS client, very widely documented.
+- [`subxt`](https://github.com/paritytech/subxt) ([book](https://docs.rs/subxt/latest/subxt/index.html)) - type-safe Rust client for Substrate chains.
+
+## Frontend: Web / TUI / MCP
+
+- [polkadot.js Apps](https://polkadot.js.org/apps/) - the reference web UX for any Substrate chain.
+- [`ratatui`](https://ratatui.rs/) - Rust TUI framework.
+- [Model Context Protocol (MCP) docs](https://modelcontextprotocol.io/) - spec and SDKs for writing an MCP server.
+
+## Deployment: Bulletin Chain + DotNS (mandatory)
+
+- [`polkadot-bulletin-chain`](https://github.com/paritytech/polkadot-bulletin-chain) - the Bulletin Chain repo; the README links out to all the current docs.
+- [`dot.li`](https://dot.li/) - DotNS link shortener.
+
+## Local dev & testing
+
+- [`zombienet`](https://github.com/paritytech/zombienet) / [`zombienet-sdk`](https://github.com/paritytech/zombienet-sdk) - spin up ephemeral multi-node networks for integration tests.
+- [Zombienet VS Code extension](https://github.com/paritytech/zombienet-vscode-extension) - IDE support for writing Zombienet specs.
+- [Chopsticks](https://docs.polkadot.com/develop/toolkit/parachains/fork-chains/chopsticks/) - fork a live chain locally and test against real state.
+
+## Testnets, RPCs, explorers
+
+- [Paseo](https://paseo.network/) - community testnet for Polkadot.
+- [telemetry.polkadot.io](https://telemetry.polkadot.io/) - live network health dashboard.
+
+## Reference & community
+
+- [Polkadot Wiki](https://wiki.polkadot.com/) - community explainers across the whole stack.
+- [Polkadot Forum](https://forum.polkadot.network/) - official discussion forum.
+- [Substrate Stack Exchange](https://substrate.stackexchange.com/) - Q&A.

--- a/projects/PBP-Lisbon-2026/retrospective-template.md
+++ b/projects/PBP-Lisbon-2026/retrospective-template.md
@@ -1,0 +1,66 @@
+# PBP Project Retrospective
+
+> Fill this in at the end of the program and commit it to the root of your project repo as `RETROSPECTIVE.md`. Keep it honest and keep it short. Reviewers read this carefully.
+
+---
+
+**Your name:**
+**Project name:**
+**Repo URL:**
+**Path chosen:** (e.g. "Pallet + React web app", "Rust contract on PVM + CLI + DotNS landing page")
+
+---
+
+## What I built
+
+*One paragraph. What does this project do? Who is it for? What problem does it solve?*
+
+---
+
+## Why I picked this path
+
+*Which backend? Which frontend? Why those choices over the alternatives? If you picked a riskier row in the path certainty matrix, why?*
+
+---
+
+## What worked
+
+*The stuff that went smoothly. What parts of the stack were a pleasure to use? What crates / tools / docs were especially helpful?*
+
+---
+
+## What broke
+
+*Be specific. "The stack is flaky" is not useful feedback. "When I tried to call `foo_bar` on a PVM contract from `polkadot-js/api` v14.2, I got an opaque error until I switched to the `polkadot-api` client, which worked after I manually patched the chain metadata" is gold.*
+
+*Link to any bug reports or PRs you filed (see below).*
+
+---
+
+## What I'd do differently
+
+*If you started over on Monday knowing what you know now, what would you change?*
+
+---
+
+## Stack feedback for Parity
+
+*This is the section Parity's product team will read. What should they know about the developer experience on this stack? What is the one thing you'd most want fixed? What would have saved you the most time? What is genuinely good and should not change?*
+
+*Be direct. You will not hurt anyone's feelings. This is why we are asking.*
+
+---
+
+## AI usage
+
+*Be honest about how you used AI in this project. Which parts? How did you verify them? What did AI get wrong that you had to fix by hand? This section is not held against you. We encourage the use of AI.*
+
+---
+
+## Links
+
+- **Bug reports filed:**
+- **PRs submitted to stack repos:**
+- **Demo video (if any):**
+- **Live deployment (if any):**
+- **Anything else worth sharing:**

--- a/projects/PBP-Lisbon-2026/retrospective-template.md
+++ b/projects/PBP-Lisbon-2026/retrospective-template.md
@@ -51,16 +51,11 @@
 
 ---
 
-## AI usage
-
-*Be honest about how you used AI in this project. Which parts? How did you verify them? What did AI get wrong that you had to fix by hand? This section is not held against you. We encourage the use of AI.*
-
----
-
 ## Links
 
 - **Bug reports filed:**
 - **PRs submitted to stack repos:**
+- **Pitch slides / presentation:**
 - **Demo video (if any):**
 - **Live deployment (if any):**
 - **Anything else worth sharing:**

--- a/projects/PBP-Lisbon-2026/retrospective-template.md
+++ b/projects/PBP-Lisbon-2026/retrospective-template.md
@@ -13,41 +13,41 @@
 
 ## What I built
 
-*One paragraph. What does this project do? Who is it for? What problem does it solve?*
+_One paragraph. What does this project do? Who is it for? What problem does it solve?_
 
 ---
 
 ## Why I picked this path
 
-*Which backend? Which frontend? Why those choices over the alternatives? If you picked a riskier row in the path certainty matrix, why?*
+_Which backend? Which frontend? Why those choices over the alternatives? If you picked a riskier row in the path certainty matrix, why?_
 
 ---
 
 ## What worked
 
-*The stuff that went smoothly. What parts of the stack were a pleasure to use? What crates / tools / docs were especially helpful?*
+_The stuff that went smoothly. What parts of the stack were a pleasure to use? What crates / tools / docs were especially helpful?_
 
 ---
 
 ## What broke
 
-*Be specific. "The stack is flaky" is not useful feedback. "When I tried to call `foo_bar` on a PVM contract from `polkadot-js/api` v14.2, I got an opaque error until I switched to the `polkadot-api` client, which worked after I manually patched the chain metadata" is gold.*
+_Be specific. "The stack is flaky" is not useful feedback. "When I tried to call `foo_bar` on a PVM contract from `polkadot-js/api` v14.2, I got an opaque error until I switched to the `polkadot-api` client, which worked after I manually patched the chain metadata" is gold._
 
-*Link to any bug reports or PRs you filed (see below).*
+_Link to any bug reports or PRs you filed (see below)._
 
 ---
 
 ## What I'd do differently
 
-*If you started over on Monday knowing what you know now, what would you change?*
+_If you started over on Monday knowing what you know now, what would you change?_
 
 ---
 
 ## Stack feedback for Parity
 
-*This is the section Parity's product team will read. What should they know about the developer experience on this stack? What is the one thing you'd most want fixed? What would have saved you the most time? What is genuinely good and should not change?*
+_This is the section Parity's product team will read. What should they know about the developer experience on this stack? What is the one thing you'd most want fixed? What would have saved you the most time? What is genuinely good and should not change?_
 
-*Be direct. You will not hurt anyone's feelings. This is why we are asking.*
+_Be direct. You will not hurt anyone's feelings. This is why we are asking._
 
 ---
 

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,14 @@
+# PBA / PBP Projects
+
+This directory holds project guidelines, idea banks, and templates for student projects for Protocol Builders Program (PBP) cohorts.
+
+## Contents
+
+- [`PBP-Lisbon-2026/`](./PBP-Lisbon-2026/) - Project guidelines for the Lisbon 2026 Protocol Builders Program cohort.
+  - [`project-guidelines.md`](./PBP-Lisbon-2026/project-guidelines.md) - main student-facing document.
+  - [`retrospective-template.md`](./PBP-Lisbon-2026/retrospective-template.md) - end-of-program write-up template.
+- [`ideas.md`](./ideas.md) - living idea bank, open to contributions from Parity product team and faculty.
+
+## Why this is a top-level directory
+
+Student projects are a first-class concern of the program - they are used for hiring consideration, and they are a feedback channel back into the Polkadot stack.

--- a/projects/ideas.md
+++ b/projects/ideas.md
@@ -4,9 +4,10 @@ A living list of project ideas for Protocol Builders Program students.
 
 **This document is open to contributions from the Parity product team, faculty, and instructors.** If you have an idea that would make a great student project add it here via PR.
 
-Students: you are free to pick an idea from this list, remix one, or invent your own. These are just  suggestions.
+Students: you are free to pick an idea from this list, remix one, or invent your own. These are just suggestions.
 
 Each idea includes:
+
 - **What it is** - one paragraph.
 - **Suggested paths** - which backend + frontend combinations fit.
 - **Why it matters** - why Parity (or the ecosystem) would care about this existing.
@@ -18,17 +19,23 @@ Each idea includes:
 > Recognizable, real-world applications. The scope is well understood, the user need is obvious, and the design space is rich. Great for showing you can take a familiar product and ship a clean version of it on a new stack.
 
 ### 1.1 Versioned markdown wiki with on-chain ACL
+
 A markdown editor / wiki where users explicitly save snapshots, stored as Bulletin Chain blobs and indexed on-chain via a pallet or contract that holds the ACL and the snapshot history. Permissioned editing, linear versioning, diff-between-snapshots view.
+
 - **Paths**: Pallet + Web; Solidity-EVM + Web.
 - **Why**: A clean, recognizable product that exercises the full stack.
 
 ### 1.2 On-chain payments / invoicing
+
 A simple invoicing + payments app. Someone creates an invoice, another account pays it, both sides get verifiable records.
+
 - **Paths**: Pallet + Web; Solidity-EVM + Web; Solidity-PVM + Web.
 - **Why**: Payments are the bread-and-butter use case for the stack. A clean, minimal version is useful reference work.
 
 ### 1.3 Ticketing / event passes
+
 Issue tickets as on-chain assets. Transferable, verifiable, optionally revocable. Gate access via signature check.
+
 - **Paths**: Pallet + Web; Solidity-EVM + Web; Pallet + TUI (for gate-checker terminals).
 - **Why**: Real demand, clean scope, many directions to take it (loyalty, membership, etc.).
 
@@ -38,9 +45,10 @@ Issue tickets as on-chain assets. Transferable, verifiable, optionally revocable
 
 > Take something interesting from another ecosystem and bring it to Polkadot. You learn the protocol, we get a port, and the ecosystem gets wider.
 
-
 ### 2.3 Ephemeral file drop ("dead drop" / time-limited share)
+
 A WeTransfer-style ephemeral share: upload a file (up to Bulletin Chain's per-blob cap), get back a link backed by a DotNS name and a content hash, recipient downloads within the retention window, file disappears. Optional access control via an on-chain ACL pallet.
+
 - **Paths**: Pallet + Web; Pallet + CLI++ (TUI or MCP) + DotNS landing page.
 - **Why**: Honest fit for what Bulletin Chain actually is - a content-addressed blob layer with a ~2-week retention window, not persistent storage.
 
@@ -51,12 +59,16 @@ A WeTransfer-style ephemeral share: upload a file (up to Bulletin Chain's per-bl
 > A well-built on-chain game is one of the more memorable things you can ship.
 
 ### 3.1 Fully on-chain turn-based game
+
 Chess, Go, a card game, a simple strategy game - all state on-chain, turns enforced by the backend, with a web or TUI front.
+
 - **Paths**: Pallet + Web; Pallet + TUI; Solidity-EVM + Web. Be carefull about the complexity of the game, it could be hard to port to EVM if its too much.
 - **Why**: Games are the clearest possible "this stack is for real applications" demo.
 
 ### 3.2 On-chain tournament / leaderboard layer
+
 Not a game itself - a backend that games can plug into for verifiable leaderboards, tournament brackets, prize pools.
+
 - **Paths**: Pallet + Web; Solidity-EVM + Web.
 - **Why**: Infra for games is a useful primitive and composable with anything else in this list. It also promotes interoperability !
 
@@ -69,25 +81,33 @@ Not a game itself - a backend that games can plug into for verifiable leaderboar
 > Each of these projects have already been done in the past - so they are battle tested and are sure to work. They are just maybe a bit less interesting if taken as is instead of coming up with something new.
 
 ### 4.1 Direct Delegation Proof of Stake
+
 A pallet that manages validators (self-registered candidates) and delegators (any account staking tokens behind a validator). Every N blocks, top-K winners become the active set. Block rewards split between the producer and their backers.
+
 - **Paths**: Pallet + Web (staking dashboard); Pallet + TUI.
 - **Why**: Staking is the canonical Substrate exercise. A clean implementation with a real frontend is a strong portfolio piece.
 - **Scope note**: Cut slashing and delegation chains from the MVP. Get the happy path + one good benchmark before reaching for either. Frontend should at minimum let a user delegate, undelegate, and see the active set.
 
 ### 4.2 Stateful Multisig
+
 A pallet that lets users create and manage multisigs with a unique on-chain address per multisig, and run the full transaction lifecycle (propose → vote → execute), plus member add/remove and a clean teardown path. North star: the original Gnosis Safe.
+
 - **Paths**: Pallet + Web (multisig management UI); Pallet + TUI.
 - **Why**: A real product with a real audience. Stateful multisigs are something Polkadot itself wants, and the UX surface is deep.
 - **Scope note**: Frontend matters here - a multisig with a bad UI is unusable. Pick this one if you actually enjoy frontend work too. Don't try to migrate from Polkadot's stateless multisig as part of the MVP; that's a stretch goal at best.
 
 ### 4.3 Free Transaction Pallet
+
 A pallet that lets users lock tokens to earn "weight credits" and spend them on fee-free transactions within a rolling time window, with a global per-period cap to prevent spam.
+
 - **Paths**: Pallet + Web (a demo app that exercises the free-tx path - e.g. a faucet, mint flow, or free-claim feature); Pallet + CLI++.
 - **Why**: A useful primitive on its own. The interesting design space is the rate-limit and fallback semantics.
 - **Scope note**: This is the most "systems primitive" of the four - the frontend story is **not** "a UI for free transactions," it's "an actual app that uses the pallet to give users free transactions." Pick the demo app with care; reviewers should walk away believing the primitive is useful.
 
 ### 4.4 Multi-Token Treasury
+
 A pallet managing a multi-asset treasury with governance-gated spending tracks, sensible handling of insufficient balances and existential deposits across assets.
+
 - **Paths**: Pallet + Web (treasury dashboard / governance UI); Pallet + TUI.
 - **Why**: Treasury mechanics are a real Polkadot need, and this exercises governance APIs and asset handling at the same time.
 - **Scope note**: Don't try to build a price oracle or DOT↔USD conversion in MVP; pick fixed token denominations and one or two spending tracks.
@@ -98,4 +118,4 @@ A pallet managing a multi-asset treasury with governance-gated spending tracks, 
 
 Your idea doesn't have to fit a category above. The best projects in programs like this are genuinely weird things a student cared or is passionate about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
 
-Things we'd love to see: anything that *only works* because of what's unique about the Polkadot stack. If your project would work just as well on Ethereum mainnet, it is probably not the most interesting version of itself.
+Things we'd love to see: anything that _only works_ because of what's unique about the Polkadot stack. If your project would work just as well on Ethereum mainnet, it is probably not the most interesting version of itself.

--- a/projects/ideas.md
+++ b/projects/ideas.md
@@ -4,7 +4,7 @@ A living list of project ideas for Protocol Builders Program students.
 
 **This document is open to contributions from the Parity product team, faculty, and instructors.** If you have an idea that would make a great student project add it here via PR.
 
-Students: you are free to pick an idea from this list, remix one, or invent your own. These are starting points, not a menu. The best projects usually come from a student taking an idea here and twisting it to fit something they personally care about.
+Students: you are free to pick an idea from this list, remix one, or invent your own. These are just  suggestions.
 
 Each idea includes:
 - **What it is** - one paragraph.
@@ -52,19 +52,21 @@ A WeTransfer-style ephemeral share: upload a file (up to Bulletin Chain's per-bl
 
 ### 3.1 Fully on-chain turn-based game
 Chess, Go, a card game, a simple strategy game - all state on-chain, turns enforced by the backend, with a web or TUI front.
-- **Paths**: Pallet + Web; Pallet + TUI; Solidity-EVM + Web.
+- **Paths**: Pallet + Web; Pallet + TUI; Solidity-EVM + Web. Be carefull about the complexity of the game, it could be hard to port to EVM if its too much.
 - **Why**: Games are the clearest possible "this stack is for real applications" demo.
 
 ### 3.2 On-chain tournament / leaderboard layer
 Not a game itself - a backend that games can plug into for verifiable leaderboards, tournament brackets, prize pools.
 - **Paths**: Pallet + Web; Solidity-EVM + Web.
-- **Why**: Infra for games is a useful primitive and composable with anything else in this list.
+- **Why**: Infra for games is a useful primitive and composable with anything else in this list. It also promotes interoperability !
 
 ---
 
 ## 4. Pallet Design Showcases
 
-> Projects where the heart of the work is designing a non-trivial Substrate pallet from first principles - economic mechanism, state transitions, edge cases, benchmarks. Each must still ship a frontend (web or CLI++) so it satisfies the rubric. These are the heaviest backend ideas in the bank - pick one if you want to flex pallet design specifically.
+> Projects where the heart of the work is designing a non-trivial Substrate pallet from first principles - economic mechanism, state transitions, edge cases, benchmarks. Each must still ship a frontend (web or CLI++) so it satisfies the rubric.
+
+> Each of these projects have already been done in the past - so they are battle tested and are sure to work. They are just maybe a bit less interesting if taken as is instead of coming up with something new.
 
 ### 4.1 Direct Delegation Proof of Stake
 A pallet that manages validators (self-registered candidates) and delegators (any account staking tokens behind a validator). Every N blocks, top-K winners become the active set. Block rewards split between the producer and their backers.
@@ -94,6 +96,6 @@ A pallet managing a multi-asset treasury with governance-gated spending tracks, 
 
 ## 5. Wildcards
 
-Your idea doesn't have to fit a category above. Some of the best projects in programs like this are genuinely weird things a student cared about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
+Your idea doesn't have to fit a category above. The best projects in programs like this are genuinely weird things a student cared or is passionate about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
 
-Things we'd love to see and would rate highly: anything that *only works* because of what's unique about the Polkadot stack. If your project would work just as well on Ethereum mainnet, it is probably not the most interesting version of itself.
+Things we'd love to see: anything that *only works* because of what's unique about the Polkadot stack. If your project would work just as well on Ethereum mainnet, it is probably not the most interesting version of itself.

--- a/projects/ideas.md
+++ b/projects/ideas.md
@@ -62,7 +62,37 @@ Not a game itself - a backend that games can plug into for verifiable leaderboar
 
 ---
 
-## 4. Wildcards
+## 4. Pallet Design Showcases
+
+> Projects where the heart of the work is designing a non-trivial Substrate pallet from first principles - economic mechanism, state transitions, edge cases, benchmarks. Each must still ship a frontend (web or CLI++) so it satisfies the rubric. These are the heaviest backend ideas in the bank - pick one if you want to flex pallet design specifically.
+
+### 4.1 Direct Delegation Proof of Stake
+A pallet that manages validators (self-registered candidates) and delegators (any account staking tokens behind a validator). Every N blocks, top-K winners become the active set. Block rewards split between the producer and their backers.
+- **Paths**: Pallet + Web (staking dashboard); Pallet + TUI.
+- **Why**: Staking is the canonical Substrate exercise. A clean implementation with a real frontend is a strong portfolio piece.
+- **Scope note**: Cut slashing and delegation chains from the MVP. Get the happy path + one good benchmark before reaching for either. Frontend should at minimum let a user delegate, undelegate, and see the active set.
+
+### 4.2 Stateful Multisig
+A pallet that lets users create and manage multisigs with a unique on-chain address per multisig, and run the full transaction lifecycle (propose → vote → execute), plus member add/remove and a clean teardown path. North star: the original Gnosis Safe.
+- **Paths**: Pallet + Web (multisig management UI); Pallet + TUI.
+- **Why**: A real product with a real audience. Stateful multisigs are something Polkadot itself wants, and the UX surface is deep.
+- **Scope note**: Frontend matters here - a multisig with a bad UI is unusable. Pick this one if you actually enjoy frontend work too. Don't try to migrate from Polkadot's stateless multisig as part of the MVP; that's a stretch goal at best.
+
+### 4.3 Free Transaction Pallet
+A pallet that lets users lock tokens to earn "weight credits" and spend them on fee-free transactions within a rolling time window, with a global per-period cap to prevent spam.
+- **Paths**: Pallet + Web (a demo app that exercises the free-tx path - e.g. a faucet, mint flow, or free-claim feature); Pallet + CLI++.
+- **Why**: A useful primitive on its own. The interesting design space is the rate-limit and fallback semantics.
+- **Scope note**: This is the most "systems primitive" of the four - the frontend story is **not** "a UI for free transactions," it's "an actual app that uses the pallet to give users free transactions." Pick the demo app with care; reviewers should walk away believing the primitive is useful.
+
+### 4.4 Multi-Token Treasury
+A pallet managing a multi-asset treasury with governance-gated spending tracks, sensible handling of insufficient balances and existential deposits across assets.
+- **Paths**: Pallet + Web (treasury dashboard / governance UI); Pallet + TUI.
+- **Why**: Treasury mechanics are a real Polkadot need, and this exercises governance APIs and asset handling at the same time.
+- **Scope note**: Don't try to build a price oracle or DOT↔USD conversion in MVP; pick fixed token denominations and one or two spending tracks.
+
+---
+
+## 5. Wildcards
 
 Your idea doesn't have to fit a category above. Some of the best projects in programs like this are genuinely weird things a student cared about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
 

--- a/projects/ideas.md
+++ b/projects/ideas.md
@@ -9,7 +9,6 @@ Students: you are free to pick an idea from this list, remix one, or invent your
 Each idea includes:
 - **What it is** - one paragraph.
 - **Suggested paths** - which backend + frontend combinations fit.
-- **Difficulty** - rough signal of how ambitious this is.
 - **Why it matters** - why Parity (or the ecosystem) would care about this existing.
 
 ---
@@ -18,22 +17,19 @@ Each idea includes:
 
 > Recognizable, real-world applications. The scope is well understood, the user need is obvious, and the design space is rich. Great for showing you can take a familiar product and ship a clean version of it on a new stack.
 
-### 1.1 Decentralized HackMD / collaborative markdown
-A collaborative, real-time markdown editor where document state lives on-chain (or on Bulletin Chain), with permissioned editing and versioning.
+### 1.1 Versioned markdown wiki with on-chain ACL
+A markdown editor / wiki where users explicitly save snapshots, stored as Bulletin Chain blobs and indexed on-chain via a pallet or contract that holds the ACL and the snapshot history. Permissioned editing, linear versioning, diff-between-snapshots view.
 - **Paths**: Pallet + Web; Solidity-EVM + Web.
-- **Difficulty**: Medium.
-- **Why**: Collaborative editing is a recognizable, hard-but-tractable problem. A clean decentralized version is a memorable demo.
+- **Why**: A clean, recognizable product that exercises the full stack.
 
 ### 1.2 On-chain payments / invoicing
 A simple invoicing + payments app. Someone creates an invoice, another account pays it, both sides get verifiable records.
 - **Paths**: Pallet + Web; Solidity-EVM + Web; Solidity-PVM + Web.
-- **Difficulty**: Easy–Medium.
 - **Why**: Payments are the bread-and-butter use case for the stack. A clean, minimal version is useful reference work.
 
 ### 1.3 Ticketing / event passes
 Issue tickets as on-chain assets. Transferable, verifiable, optionally revocable. Gate access via signature check.
 - **Paths**: Pallet + Web; Solidity-EVM + Web; Pallet + TUI (for gate-checker terminals).
-- **Difficulty**: Easy–Medium.
 - **Why**: Real demand, clean scope, many directions to take it (loyalty, membership, etc.).
 
 ---
@@ -42,23 +38,11 @@ Issue tickets as on-chain assets. Transferable, verifiable, optionally revocable
 
 > Take something interesting from another ecosystem and bring it to Polkadot. You learn the protocol, we get a port, and the ecosystem gets wider.
 
-### 2.1 x402 payments
-HTTP-native micropayments using the x402 spec, but backed by Polkadot accounts and an on-chain / Bulletin-Chain settlement layer.
-- **Paths**: Pallet or Solidity-EVM backend + Web or MCP frontend.
-- **Difficulty**: Medium.
-- **Why**: x402 is getting real traction. A Polkadot-native implementation is a cool standalone thing and a useful primitive.
 
-### 2.2 Anonymous / encrypted chat
-End-to-end encrypted chat where metadata (ciphertext, recipient hints) lives on Bulletin Chain / Statement Store.
-- **Paths**: Pallet + Web; Pallet + TUI.
-- **Difficulty**: Medium–Hard (crypto done wrong is worse than no crypto - be careful and ask for review).
-- **Why**: Shows what decentralized storage can do, and it's genuinely useful.
-
-### 2.3 Decentralized file hosting
-Upload, pin, retrieve, share files through Bulletin Chain, with access control via on-chain logic.
+### 2.3 Ephemeral file drop ("dead drop" / time-limited share)
+A WeTransfer-style ephemeral share: upload a file (up to Bulletin Chain's per-blob cap), get back a link backed by a DotNS name and a content hash, recipient downloads within the retention window, file disappears. Optional access control via an on-chain ACL pallet.
 - **Paths**: Pallet + Web; Pallet + CLI++ (TUI or MCP) + DotNS landing page.
-- **Difficulty**: Medium.
-- **Why**: File hosting is a something that the web3 ecosystem craves and the stack has real building blocks for it.
+- **Why**: Honest fit for what Bulletin Chain actually is - a content-addressed blob layer with a ~2-week retention window, not persistent storage.
 
 ---
 
@@ -69,42 +53,16 @@ Upload, pin, retrieve, share files through Bulletin Chain, with access control v
 ### 3.1 Fully on-chain turn-based game
 Chess, Go, a card game, a simple strategy game - all state on-chain, turns enforced by the backend, with a web or TUI front.
 - **Paths**: Pallet + Web; Pallet + TUI; Solidity-EVM + Web.
-- **Difficulty**: Medium.
 - **Why**: Games are the clearest possible "this stack is for real applications" demo.
 
 ### 3.2 On-chain tournament / leaderboard layer
 Not a game itself - a backend that games can plug into for verifiable leaderboards, tournament brackets, prize pools.
 - **Paths**: Pallet + Web; Solidity-EVM + Web.
-- **Difficulty**: Medium.
 - **Why**: Infra for games is a useful primitive and composable with anything else in this list.
 
 ---
 
-## 4. Infra & Tooling
-
-> Less glamorous but genuinely useful. Good tooling work has a long tail of impact.
-
-### 4.1 MCP server for a Polkadot chain
-An MCP server that lets an AI agent (Claude, etc.) query and interact with a Polkadot chain - read state, submit extrinsics, inspect accounts. Your "frontend" is the MCP interface; the "backend" is a small supporting pallet or contract.
-- **Paths**: Pallet + MCP; Solidity-EVM + MCP.
-- **Difficulty**: Medium.
-- **Why**: MCP is hot, and making the Polkadot stack legible to AI agents is a real unlock for the ecosystem.
-
-### 4.2 DotNS-based deploy tool
-A tool that publishes a built web app to Bulletin Chain and registers it under a DotNS name in one command. Your backend is a supporting pallet or contract that tracks deployments. To clear the CLI++ bar, build it as a TUI with live deploy progress, or expose it as an MCP server so an AI agent can deploy on your behalf.
-- **Paths**: Pallet + CLI++ (TUI or MCP).
-- **Difficulty**: Medium.
-- **Why**: The stack needs frictionless deploy workflows. If yours is good, people will actually use it.
-
-### 4.3 Local-first dev dashboard
-A TUI that gives you a live view of a running local node: blocks, extrinsics, logs, storage, events. Your backend is a pallet or contract you then exercise from the TUI to prove it works.
-- **Paths**: Pallet + TUI.
-- **Difficulty**: Medium.
-- **Why**: Good DX tooling is always undersupplied and always appreciated.
-
----
-
-## 5. Wildcards
+## 4. Wildcards
 
 Your idea doesn't have to fit a category above. Some of the best projects in programs like this are genuinely weird things a student cared about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
 

--- a/projects/ideas.md
+++ b/projects/ideas.md
@@ -1,0 +1,111 @@
+# PBP Project Idea Bank
+
+A living list of project ideas for Protocol Builders Program students.
+
+**This document is open to contributions from the Parity product team, faculty, and instructors.** If you have an idea that would make a great student project add it here via PR.
+
+Students: you are free to pick an idea from this list, remix one, or invent your own. These are starting points, not a menu. The best projects usually come from a student taking an idea here and twisting it to fit something they personally care about.
+
+Each idea includes:
+- **What it is** - one paragraph.
+- **Suggested paths** - which backend + frontend combinations fit.
+- **Difficulty** - rough signal of how ambitious this is.
+- **Why it matters** - why Parity (or the ecosystem) would care about this existing.
+
+---
+
+## 1. Practical Apps
+
+> Recognizable, real-world applications. The scope is well understood, the user need is obvious, and the design space is rich. Great for showing you can take a familiar product and ship a clean version of it on a new stack.
+
+### 1.1 Decentralized HackMD / collaborative markdown
+A collaborative, real-time markdown editor where document state lives on-chain (or on Bulletin Chain), with permissioned editing and versioning.
+- **Paths**: Pallet + Web; Solidity-EVM + Web.
+- **Difficulty**: Medium.
+- **Why**: Collaborative editing is a recognizable, hard-but-tractable problem. A clean decentralized version is a memorable demo.
+
+### 1.2 On-chain payments / invoicing
+A simple invoicing + payments app. Someone creates an invoice, another account pays it, both sides get verifiable records.
+- **Paths**: Pallet + Web; Solidity-EVM + Web; Solidity-PVM + Web.
+- **Difficulty**: Easy–Medium.
+- **Why**: Payments are the bread-and-butter use case for the stack. A clean, minimal version is useful reference work.
+
+### 1.3 Ticketing / event passes
+Issue tickets as on-chain assets. Transferable, verifiable, optionally revocable. Gate access via signature check.
+- **Paths**: Pallet + Web; Solidity-EVM + Web; Pallet + TUI (for gate-checker terminals).
+- **Difficulty**: Easy–Medium.
+- **Why**: Real demand, clean scope, many directions to take it (loyalty, membership, etc.).
+
+---
+
+## 2. Protocol Ports From Other Chains
+
+> Take something interesting from another ecosystem and bring it to Polkadot. You learn the protocol, we get a port, and the ecosystem gets wider.
+
+### 2.1 x402 payments
+HTTP-native micropayments using the x402 spec, but backed by Polkadot accounts and an on-chain / Bulletin-Chain settlement layer.
+- **Paths**: Pallet or Solidity-EVM backend + Web or MCP frontend.
+- **Difficulty**: Medium.
+- **Why**: x402 is getting real traction. A Polkadot-native implementation is a cool standalone thing and a useful primitive.
+
+### 2.2 Anonymous / encrypted chat
+End-to-end encrypted chat where metadata (ciphertext, recipient hints) lives on Bulletin Chain / Statement Store.
+- **Paths**: Pallet + Web; Pallet + TUI.
+- **Difficulty**: Medium–Hard (crypto done wrong is worse than no crypto - be careful and ask for review).
+- **Why**: Shows what decentralized storage can do, and it's genuinely useful.
+
+### 2.3 Decentralized file hosting
+Upload, pin, retrieve, share files through Bulletin Chain, with access control via on-chain logic.
+- **Paths**: Pallet + Web; Pallet + CLI++ (TUI or MCP) + DotNS landing page.
+- **Difficulty**: Medium.
+- **Why**: File hosting is a something that the web3 ecosystem craves and the stack has real building blocks for it.
+
+---
+
+## 3. Games
+
+> A well-built on-chain game is one of the more memorable things you can ship.
+
+### 3.1 Fully on-chain turn-based game
+Chess, Go, a card game, a simple strategy game - all state on-chain, turns enforced by the backend, with a web or TUI front.
+- **Paths**: Pallet + Web; Pallet + TUI; Solidity-EVM + Web.
+- **Difficulty**: Medium.
+- **Why**: Games are the clearest possible "this stack is for real applications" demo.
+
+### 3.2 On-chain tournament / leaderboard layer
+Not a game itself - a backend that games can plug into for verifiable leaderboards, tournament brackets, prize pools.
+- **Paths**: Pallet + Web; Solidity-EVM + Web.
+- **Difficulty**: Medium.
+- **Why**: Infra for games is a useful primitive and composable with anything else in this list.
+
+---
+
+## 4. Infra & Tooling
+
+> Less glamorous but genuinely useful. Good tooling work has a long tail of impact.
+
+### 4.1 MCP server for a Polkadot chain
+An MCP server that lets an AI agent (Claude, etc.) query and interact with a Polkadot chain - read state, submit extrinsics, inspect accounts. Your "frontend" is the MCP interface; the "backend" is a small supporting pallet or contract.
+- **Paths**: Pallet + MCP; Solidity-EVM + MCP.
+- **Difficulty**: Medium.
+- **Why**: MCP is hot, and making the Polkadot stack legible to AI agents is a real unlock for the ecosystem.
+
+### 4.2 DotNS-based deploy tool
+A tool that publishes a built web app to Bulletin Chain and registers it under a DotNS name in one command. Your backend is a supporting pallet or contract that tracks deployments. To clear the CLI++ bar, build it as a TUI with live deploy progress, or expose it as an MCP server so an AI agent can deploy on your behalf.
+- **Paths**: Pallet + CLI++ (TUI or MCP).
+- **Difficulty**: Medium.
+- **Why**: The stack needs frictionless deploy workflows. If yours is good, people will actually use it.
+
+### 4.3 Local-first dev dashboard
+A TUI that gives you a live view of a running local node: blocks, extrinsics, logs, storage, events. Your backend is a pallet or contract you then exercise from the TUI to prove it works.
+- **Paths**: Pallet + TUI.
+- **Difficulty**: Medium.
+- **Why**: Good DX tooling is always undersupplied and always appreciated.
+
+---
+
+## 5. Wildcards
+
+Your idea doesn't have to fit a category above. Some of the best projects in programs like this are genuinely weird things a student cared about. If you have one, bring it to a faculty conversation early and we'll help you shape it.
+
+Things we'd love to see and would rate highly: anything that *only works* because of what's unique about the Polkadot stack. If your project would work just as well on Ethereum mainnet, it is probably not the most interesting version of itself.


### PR DESCRIPTION
## Summary

Introduces a top-level `projects/` directory for student project material, starting with the PBP Lisbon 2026 cohort. Nothing in `syllabus/` changes.

New files:

- **`projects/README.md`** — orientation for the whole `projects/` tree 
- **`projects/PBP-Lisbon-2026/project-guidelines.md`** — the main student-facing document. Covers:
  - Framing: students are building on a stack that is not final yet; sharp edges are expected and good bug reports are valued.
  - Hiring reality check — **no grades; projects are reviewed directly by Parity for hiring consideration**.
  - Hard scope: one backend (Substrate pallet / Solidity-EVM / Solidity-PVM / Rust-PVM) + one frontend (Web or CLI++ → TUI or MCP server) + mandatory Bulletin Chain + DotNS deploy.
  - Path certainty matrix (advisory, ~100% → ~50% depending on backend).
  - Bonus dimensions (stack PRs, protocol ports, reusable tooling, etc.).
  - **AI usage policy** ("No Slop"): AI is allowed and encouraged, but students own every line — responsibilities, red flags reviewers will catch, and a stricter 90/10 rule for README prose.
  - Deliverables, pre-submit checklist, pitch-day format (5 min + 2 min Q&A), timeline, and support / office-hours guidance.
- **`projects/PBP-Lisbon-2026/retrospective-template.md`** — short post-mortem template each student commits to their repo as `RETROSPECTIVE.md`. Has a dedicated "Stack feedback for Parity" section the product team will read.
- **`projects/PBP-Lisbon-2026/resources.md`** — curated starter pointers: templates, backend/frontend links per path, Bulletin Chain + DotNS deploy docs. Meant to evolve via PRs.
- **`projects/ideas.md`** — living idea bank.

## Scope / non-goals

- **No changes to `syllabus/`**, `README.md`, or any cohort material. A follow-up PR will cross-link from the root README and `syllabus/README.md` once this lands (trying to do it here would mean broken links until merge).
- **Lisbon-specific only.** Future cohorts get their own sibling directory under `projects/` (`PBP-<city>-<year>/`), so each cohort's guidelines can evolve independently without rewriting history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)