### PR TITLE
Fix slide logo to link back to agenda page

### DIFF
--- a/assets/templates/slide-template.html
+++ b/assets/templates/slide-template.html
@@ -37,7 +37,7 @@
 
 <body class="site">
   <footer style="position: fixed; top: 1.5%; left: 2%; z-index: 99;">
-    <a href="{{{absoluteUrl}}}">
+    <a href="{{{base}}}/index.html">
       <img style="height: 3vw;" src="{{{base}}}/assets/img/0-Shared/logo/PBA_Logo_white.png"
         alt="PBA Logo">
     </a>


### PR DESCRIPTION
## Summary
- Change the slide template logo link from `{{{absoluteUrl}}}` (which pointed to the first slide or was empty) to `{{{base}}}/index.html` (which navigates back to the agenda/table of contents page)

## Test plan
- [x] Open a slide deck, click the PBA logo in the top-left corner
- [x] Verify it navigates back to the agenda page, not the first slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)